### PR TITLE
Finish tooltip

### DIFF
--- a/packages/daisy/src/components/tooltip/tooltip.tsx
+++ b/packages/daisy/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,11 @@
+import { component$, Slot } from "@builder.io/qwik";
+import { Tooltip as TooltipHeadless, TooltipProps as TooltipHeadlessProps } from "@qwik-ui/headless";
+
+export interface TooltipProps extends TooltipHeadlessProps {
+
+}
+export const Tooltip = component$((props: TooltipProps) => {
+  return <TooltipHeadless {...props} class={"inline-block bg-black text-white p-2 rounded-lg z-[99]" + " " + (props.class || '')}  >
+    <Slot/>
+  </TooltipHeadless>
+})

--- a/packages/daisy/src/index.ts
+++ b/packages/daisy/src/index.ts
@@ -2,3 +2,4 @@ export * from './components/collapse/collapse';
 export * from './components/drawer/drawer';
 export * from './components/tabs';
 export * from './components/toggle/toggle';
+export * from './components/tooltip/tooltip';

--- a/packages/headless/src/components/tooltip/tooltip.css
+++ b/packages/headless/src/components/tooltip/tooltip.css
@@ -1,0 +1,28 @@
+*[data-state] {
+  z-index: 99;
+  position: absolute;
+  opacity: 0;
+  transition: opacity var(--duration) linear;
+}
+
+*[data-state="positioned"] {
+  display: block;
+  top: var(--y, 0px);
+  left: var(--x, 0px);
+  opacity: 1;
+}
+
+*[data-state="unpositioned"] {
+  display: block;
+  visibility: 'hidden';
+}
+
+*[data-state="fading"] {
+  top: var(--y, 0px);
+  left: var(--x, 0px);
+  opacity: 0;
+}
+
+*[data-state="hidden"] {
+  display: none;
+}

--- a/packages/headless/src/components/tooltip/tooltip.css
+++ b/packages/headless/src/components/tooltip/tooltip.css
@@ -5,24 +5,24 @@
   transition: opacity var(--duration) linear;
 }
 
-*[data-state="positioned"] {
+*[data-state='positioned'] {
   display: block;
   top: var(--y, 0px);
   left: var(--x, 0px);
   opacity: 1;
 }
 
-*[data-state="unpositioned"] {
+*[data-state='unpositioned'] {
   display: block;
   visibility: 'hidden';
 }
 
-*[data-state="fading"] {
+*[data-state='fading'] {
   top: var(--y, 0px);
   left: var(--x, 0px);
   opacity: 0;
 }
 
-*[data-state="hidden"] {
+*[data-state='hidden'] {
   display: none;
 }

--- a/packages/headless/src/components/tooltip/tooltip.tsx
+++ b/packages/headless/src/components/tooltip/tooltip.tsx
@@ -6,25 +6,29 @@ import {
   useId,
   useOnWindow,
   useSignal,
+  useStylesScoped$
 } from '@builder.io/qwik';
 import { computePosition, type ComputePositionConfig } from '@floating-ui/dom';
+import styles from "./tooltip.css?inline";
 
-interface TooltipProps {
-  content?: string;
+export interface TooltipProps {
+  class?: string;
+  content: string;
   inline?: boolean;
+  durationMs?: number
   position?: ComputePositionConfig['placement'];
 }
 
-type TooltipState = 'NotInDom' | 'InDomNotVisible' | 'inDomVisible';
+type State = "hidden" | "positioned" | "unpositioned" | "fading";
 
 export const Tooltip = component$(
-  ({ content, position = 'top', ...props }: TooltipProps) => {
+  ({ content, position = 'top', durationMs = 100, ...props }: TooltipProps) => {
+    useStylesScoped$(styles);
     const id = useId();
     const triggerAnchor = useSignal<HTMLElement>();
     const tooltipAnchor = useSignal<HTMLElement>();
-    const isTooltipVisible = useSignal<boolean>(false);
-    const xSignal = useSignal<number>(0);
-    const ySignal = useSignal<number>(0);
+    const stateSignal = useSignal<State>("hidden");
+    const positionSignal = useSignal<{x: number, y: number}>({x: 0, y: 0});
 
     const Wrapper: keyof HTMLElementTagNameMap = props.inline ? 'span' : 'div';
 
@@ -37,18 +41,20 @@ export const Tooltip = component$(
             placement: position,
           }
         );
-        console.log(`x: ${x} y: ${y}`);
-        xSignal.value = x;
-        ySignal.value = y;
+        positionSignal.value = {x, y};
+        stateSignal.value = 'positioned';
+        console.log("Update", positionSignal.value)
       }
     });
 
     const showTooltip = $(() => {
-      isTooltipVisible.value = true;
+      stateSignal.value = 'unpositioned';
+      console.log("Show Tooltip", positionSignal.value)
     });
 
     const hideTooltip = $(() => {
-      isTooltipVisible.value = false;
+      stateSignal.value = 'fading';
+      console.log("Hide tooltip", positionSignal.value)
     });
 
     useOnWindow(
@@ -64,10 +70,11 @@ export const Tooltip = component$(
     );
 
     useClientEffect$(({ track }) => {
-      const visible = track(() => isTooltipVisible.value);
-      if (visible) {
+      const state = track(() => stateSignal.value);
+      if (state == 'unpositioned') {
         // run auto update
         update();
+        console.log("Client Effect", positionSignal.value)
       } else {
         // Cleanup auto update listeners
       }
@@ -90,17 +97,23 @@ export const Tooltip = component$(
         </Wrapper>
 
         <Wrapper
+          class={`${stateSignal.value} ${props.class || ''}`}
           id={id}
+          onAnimationEnd$={() => {
+            if (stateSignal.value == "fading") {
+              stateSignal.value = 'hidden';
+              positionSignal.value = { x: 0, y: 0 }
+            }
+          }}
           ref={tooltipAnchor}
           role="tooltip"
           {...props}
           // Cannot be animated
-          style={`display: ${isTooltipVisible.value ? 'block' : 'none'};
-            position: absolute;
-            left: ${xSignal.value}px;
-            top: ${ySignal.value}px;`}
+          style={`--duration: ${durationMs}ms;--x: ${positionSignal.value.x || 0}px; --y: ${positionSignal.value.y || 0}px;`}
+          data-state={stateSignal.value}
         >
-          {content ? content : <Slot name="tooltip-content" />}
+          {content}
+          {/* {content ? content : <Slot name="tooltip-content" />} */}
         </Wrapper>
       </>
     );

--- a/packages/headless/src/components/tooltip/tooltip.tsx
+++ b/packages/headless/src/components/tooltip/tooltip.tsx
@@ -43,29 +43,24 @@ export const Tooltip = component$(
         );
         positionSignal.value = {x, y};
         stateSignal.value = 'positioned';
-        console.log("Update", positionSignal.value)
       }
     });
 
     const showTooltip = $(() => {
       stateSignal.value = 'unpositioned';
-      console.log("Show Tooltip", positionSignal.value)
     });
 
     const hideTooltip = $(() => {
       stateSignal.value = 'fading';
-      console.log("Hide tooltip", positionSignal.value)
     });
 
     useOnWindow(
       'keyup',
       $((e) => {
         const key = (e as KeyboardEvent).key;
-        console.log('e.key', (e as KeyboardEvent).key);
         if (key === 'Escape') {
           hideTooltip();
         }
-        // if the key pressed was escape, hide the tip.
       })
     );
 
@@ -74,7 +69,6 @@ export const Tooltip = component$(
       if (state == 'unpositioned') {
         // run auto update
         update();
-        console.log("Client Effect", positionSignal.value)
       } else {
         // Cleanup auto update listeners
       }

--- a/packages/headless/src/components/tooltip/tooltip.tsx
+++ b/packages/headless/src/components/tooltip/tooltip.tsx
@@ -6,20 +6,20 @@ import {
   useId,
   useOnWindow,
   useSignal,
-  useStylesScoped$
+  useStylesScoped$,
 } from '@builder.io/qwik';
 import { computePosition, type ComputePositionConfig } from '@floating-ui/dom';
-import styles from "./tooltip.css?inline";
+import styles from './tooltip.css?inline';
 
 export interface TooltipProps {
   class?: string;
   content: string;
   inline?: boolean;
-  durationMs?: number
+  durationMs?: number;
   position?: ComputePositionConfig['placement'];
 }
 
-type State = "hidden" | "positioned" | "unpositioned" | "fading";
+type State = 'hidden' | 'positioned' | 'unpositioned' | 'closing';
 
 export const Tooltip = component$(
   ({ content, position = 'top', durationMs = 100, ...props }: TooltipProps) => {
@@ -27,8 +27,8 @@ export const Tooltip = component$(
     const id = useId();
     const triggerAnchor = useSignal<HTMLElement>();
     const tooltipAnchor = useSignal<HTMLElement>();
-    const stateSignal = useSignal<State>("hidden");
-    const positionSignal = useSignal<{x: number, y: number}>({x: 0, y: 0});
+    const stateSignal = useSignal<State>('hidden');
+    const positionSignal = useSignal<{ x: number; y: number }>({ x: 0, y: 0 });
 
     const Wrapper: keyof HTMLElementTagNameMap = props.inline ? 'span' : 'div';
 
@@ -41,7 +41,7 @@ export const Tooltip = component$(
             placement: position,
           }
         );
-        positionSignal.value = {x, y};
+        positionSignal.value = { x, y };
         stateSignal.value = 'positioned';
       }
     });
@@ -51,7 +51,7 @@ export const Tooltip = component$(
     });
 
     const hideTooltip = $(() => {
-      stateSignal.value = 'fading';
+      stateSignal.value = 'closing';
     });
 
     useOnWindow(
@@ -94,16 +94,18 @@ export const Tooltip = component$(
           class={`${stateSignal.value} ${props.class || ''}`}
           id={id}
           onAnimationEnd$={() => {
-            if (stateSignal.value == "fading") {
+            if (stateSignal.value == 'closing') {
               stateSignal.value = 'hidden';
-              positionSignal.value = { x: 0, y: 0 }
+              positionSignal.value = { x: 0, y: 0 };
             }
           }}
           ref={tooltipAnchor}
           role="tooltip"
           {...props}
           // Cannot be animated
-          style={`--duration: ${durationMs}ms;--x: ${positionSignal.value.x || 0}px; --y: ${positionSignal.value.y || 0}px;`}
+          style={`--duration: ${durationMs}ms;--x: ${
+            positionSignal.value.x || 0
+          }px; --y: ${positionSignal.value.y || 0}px;`}
           data-state={stateSignal.value}
         >
           {content}

--- a/packages/website/src/routes/daisy-example/index.tsx
+++ b/packages/website/src/routes/daisy-example/index.tsx
@@ -1,6 +1,6 @@
 import { component$, useSignal } from '@builder.io/qwik';
 import type { DocumentHead } from '@builder.io/qwik-city';
-import { Collapse, Drawer, Tab, TabPanel, Tabs, Toggle } from '@qwik-ui/daisy';
+import { Collapse, Drawer, Tab, TabPanel, Tabs, Toggle, Tooltip } from '@qwik-ui/daisy';
 
 export default component$(() => {
   const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
@@ -9,6 +9,26 @@ export default component$(() => {
 
   return (
     <div>
+
+<div>
+        Hey I am a text and you can &nbsp;
+        <Tooltip
+          inline={true}
+          position="bottom"
+          content="Hi this is the message"
+        >
+          hover on me
+          <div q:slot="tooltip-content">Custom thing</div>
+        </Tooltip>
+      </div>
+
+      <hr />
+
+      <Tooltip content="Hi this is the message">
+        <div style="width: 100px; height: 100px; background-color: red;"></div>
+        <div q:slot="tooltip-content">Custom thing</div>
+      </Tooltip>
+
       <div style="width: 300px">
         <Collapse showArrow={true}>
           <label q:slot="label">Hi Glenn and Gil!</label>
@@ -25,20 +45,20 @@ export default component$(() => {
           {tabs.map((tab, index) => {
             return (
               <Tab
+                key={index}
                 onClick$={(clicked: number) => {
                   activeTab.value = clicked;
                 }}
                 isLifted={false}
                 isBordered={true}
-                isActive={index === activeTab.value}
               >
                 {tab}
               </Tab>
             );
           })}
-          {tabs.map((tab) => {
+          {tabs.map((tab, index) => {
             return (
-              <TabPanel>
+              <TabPanel key={index}>
                 <div>
                   {tab} {tab} {tab}
                 </div>
@@ -89,10 +109,15 @@ export default component$(() => {
                 collapse-title text-xl font-medium collapse-content max-h-fit tabs tabs-boxed 
                 tab tab-active tab-bordered tab-lifted form-control abel cursor-pointer toggle label-text
                 drawer
+                bg-black
+                text-white
+                rounded-lg
+                p-2
                 drawer-toggle
                 btn btn-primary drawer-button
                 drawer-side
                 drawer-overlay
+                tooltip
                 `}
       />
     </div>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Adds explicit states to the tool tip to handle 
 - Hidden
 - Positioned
 - Unpositioned
 - Closing

Adds default css transition with 100ms duration. Allows duration to be configured.
Adds Daisy implementation with basic styling.

There does not seem to be a way to map a named slot in Daisy to a named slot in Headless. Until a solution can be found tooltip content will have to be a simple string.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
