### PR TITLE
docs(wrapper code for component documentation): wrapper allow display…

### DIFF
--- a/packages/website/src/components/wrapper/wrapper.css
+++ b/packages/website/src/components/wrapper/wrapper.css
@@ -1,0 +1,51 @@
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+  padding-bottom: 20px;
+  align-items: baseline;
+}
+
+h1 small {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+h1::after {
+  content: '';
+  border-width: 2px;
+  border-color: #01B9FC;
+  margin-left: 0;
+  margin-top: 30px;
+  margin-bottom: 30px;
+  width: 45px;
+  position: absolute;
+  bottom: -15px;
+  left: 0;
+}
+
+.description {
+  margin-bottom: 20px;
+}
+.section-wrapper {
+  background: #fff;
+  border: 1px solid #cbc8c8;
+  width: 100%;
+}
+.section-content {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+.section-header {
+  background: #ebebeb;
+  display: flex;
+  justify-content: end;
+}
+
+.section-content {
+  display: flex;
+}

--- a/packages/website/src/components/wrapper/wrapper.tsx
+++ b/packages/website/src/components/wrapper/wrapper.tsx
@@ -1,0 +1,49 @@
+import { component$, Slot, useSignal, useStylesScoped$ } from '@builder.io/qwik';
+import { Tab, TabPanel, Tabs } from '@qwik-ui/theme-daisy';
+import styles from './wrapper.css?inline';
+
+export interface WrapperProps {
+  title?: string;
+  subtitle?: string;
+  description?: string;
+}
+
+export const Wrapper = component$(
+  ({ title, subtitle, description }: WrapperProps) => {
+  useStylesScoped$(styles);
+
+  const options = ['Preview', 'Code'];
+  const activeTab = useSignal(0);
+  return (
+    <>
+      <h1>{ title } <small>{subtitle}</small></h1>
+      <p class="description">{description}</p>
+      <div class="section-wrapper">
+        <Tabs class="section-content">
+         <div class="section-header">
+            {options.map((option, index)  => {
+              return (
+                  <Tab
+                    key={index}
+                    onClick$={(clicked: number) => {
+                      activeTab.value = clicked;
+                    }}
+                    >
+                    { option }
+                  </Tab>
+              )
+            })}
+          </div>
+          <div class="section-content">
+            <TabPanel key={'panel'}>
+              <Slot name="preview" />
+            </TabPanel>
+            <TabPanel key={'panel1'}>
+              <Slot name="code" />
+            </TabPanel>
+          </div>
+        </Tabs>
+      </div>
+      </>
+    );
+  });

--- a/packages/website/src/routes/daisy/tabs/index.tsx
+++ b/packages/website/src/routes/daisy/tabs/index.tsx
@@ -1,39 +1,63 @@
 import { component$, useSignal } from '@builder.io/qwik';
 import { Tab, TabPanel, Tabs } from '@qwik-ui/theme-daisy';
+import { Wrapper } from 'packages/website/src/components/wrapper/wrapper';
 
 export default component$(() => {
   const tabs = ['Tab 1', 'Tab 2', 'Tab 3'];
   const activeTab = useSignal(0);
   return (
     <>
-      <h2>This is the documentation for the Tabs</h2>
-      <div style="width: 300px">
-        <Tabs>
-          {tabs.map((tab, index) => {
-            return (
-              <Tab
-                key={index}
-                onClick$={(clicked: number) => {
-                  activeTab.value = clicked;
-                }}
-                isLifted={false}
-                isBordered={true}
-              >
-                {tab}
-              </Tab>
-            );
-          })}
-          {tabs.map((tab, index) => {
-            return (
-              <TabPanel key={'panel' + index}>
-                <div>
-                  {tab} {tab} {tab}
-                </div>
-              </TabPanel>
-            );
-          })}
-        </Tabs>
-      </div>
+      <h2></h2>
+      <Wrapper
+        title='Tabs'
+        subtitle='Daisy'
+        description='This is the documentation for the Tabs'>
+        <div q:slot="preview">
+          <div style="width: 300px">
+            <Tabs>
+              {tabs.map((tab, index) => {
+                return (
+                  <Tab
+                    key={index}
+                    onClick$={(clicked: number) => {
+                      activeTab.value = clicked;
+                    }}
+                    isLifted={false}
+                    isBordered={true}
+                  >
+                    {tab}
+                  </Tab>
+                );
+              })}
+              {tabs.map((tab, index) => {
+                return (
+                  <TabPanel key={'panel' + index}>
+                    <div>
+                      {tab} {tab} {tab}
+                    </div>
+                  </TabPanel>
+                );
+              })}
+            </Tabs>
+          </div>
+        </div>
+        <div q:slot="code">
+          <pre>
+            { ' <Tabs> '} <br />
+            { ' <Tab '}<br />
+            { '     key={index} '}<br />
+            { '     onClick$={(clicked: number) => { '}<br />
+            { '     activeTab.value = clicked; '}<br />
+                { ' }} '}<br />
+                { '  isLifted={false} '}<br />
+                { '  isBordered={true} '}<br />
+                { '  > '}<br />
+                { '   {tab} '}<br />
+                { ' </Tab> '}<br />
+          </pre>
+        </div>
+      </Wrapper>
+
     </>
   );
 });


### PR DESCRIPTION
… preview and code mode

when you use this wrapper component then you can display on documentation information about component

# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Here is video how this looks like:
[https://www.loom.com/share/8befa6c5e0564b30beba0448fdbea18c](https://www.loom.com/share/8befa6c5e0564b30beba0448fdbea18c)

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- We can use this component in another page in our documentations

# Screenshots/Demo

<img width="1123" alt="Screenshot_2023-01-25_at_14 31 24" src="https://user-images.githubusercontent.com/10683327/214614776-e20f302b-60b0-4327-b3f3-bf5a30b7d154.png">


# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
