### PR TITLE
fix(component): add TS support for HTMLButton properties

### DIFF
--- a/packages/daisy/src/components/button/button.tsx
+++ b/packages/daisy/src/components/button/button.tsx
@@ -1,12 +1,11 @@
-import { component$, HTMLAttributes, Slot } from '@builder.io/qwik';
+import { component$, QwikIntrinsicElements, Slot } from '@builder.io/qwik';
 import { Button as HeadlessButton } from '@qwik-ui/headless';
 
-type ButtonProps = {
-  disabled?: boolean;
-};
+export type ButtonProps = QwikIntrinsicElements['button'];
+
 
 export const Button = component$(
-  (props: ButtonProps & HTMLAttributes<HTMLButtonElement>) => {
+  (props: ButtonProps) => {
     return (
       <HeadlessButton class="btn btn-primary" {...props}>
         <Slot />

--- a/packages/headless/src/components/button/button.tsx
+++ b/packages/headless/src/components/button/button.tsx
@@ -1,11 +1,9 @@
-import { component$, HTMLAttributes, Slot } from '@builder.io/qwik';
+import { component$, QwikIntrinsicElements, Slot } from '@builder.io/qwik';
 
-type ButtonProps = {
-  disabled?: boolean;
-};
+export type ButtonProps = QwikIntrinsicElements['button'];
 
 export const Button = component$(
-  (props: ButtonProps & HTMLAttributes<HTMLButtonElement>) => {
+  (props: ButtonProps) => {
     return (
       <button {...props}>
         <Slot />

--- a/packages/website/src/root.tsx
+++ b/packages/website/src/root.tsx
@@ -1,5 +1,9 @@
 import { component$ } from '@builder.io/qwik';
-import { QwikCity, RouterOutlet, ServiceWorkerRegister } from '@builder.io/qwik-city';
+import {
+  QwikCity,
+  RouterOutlet,
+  ServiceWorkerRegister,
+} from '@builder.io/qwik-city';
 import { RouterHead } from './components/router-head/router-head';
 
 import './global.css';

--- a/packages/website/src/routes/docs/daisy/button/index.tsx
+++ b/packages/website/src/routes/docs/daisy/button/index.tsx
@@ -14,7 +14,9 @@ export default component$(() => {
 
         <div>
           <h2>Attributes</h2>
-          <Button type="button" disabled={true}>DISABLED BUTTON</Button>
+          <Button type="button" disabled={true}>
+            DISABLED BUTTON
+          </Button>
         </div>
 
         <div>

--- a/packages/website/src/routes/docs/daisy/button/index.tsx
+++ b/packages/website/src/routes/docs/daisy/button/index.tsx
@@ -5,9 +5,23 @@ export default component$(() => {
   return (
     <>
       <h2>This is the documentation for the Button</h2>
-      <Button onClick$={$(() => window.alert('hello'))}>CLICK ME</Button>
-      <hr />
-      <Button disabled={true}>CLICK ME</Button>
+
+      <div className="flex flex-col gap-8 mt-4">
+        <div>
+          <h2>Basic Example</h2>
+          <Button>SIMPLE BUTTON</Button>
+        </div>
+
+        <div>
+          <h2>Attributes</h2>
+          <Button type="button" disabled={true}>DISABLED BUTTON</Button>
+        </div>
+
+        <div>
+          <h2>Events</h2>
+          <Button onClick$={$(() => window.alert('hello'))}>SHOW ALERT</Button>
+        </div>
+      </div>
     </>
   );
 });

--- a/packages/website/src/routes/docs/headless/button/index.tsx
+++ b/packages/website/src/routes/docs/headless/button/index.tsx
@@ -13,7 +13,9 @@ export default component$(() => {
 
         <div>
           <h2>Attributes</h2>
-          <Button type="button" disabled={true}>DISABLED BUTTON</Button>
+          <Button type="button" disabled={true}>
+            DISABLED BUTTON
+          </Button>
         </div>
 
         <div>

--- a/packages/website/src/routes/docs/headless/button/index.tsx
+++ b/packages/website/src/routes/docs/headless/button/index.tsx
@@ -5,9 +5,22 @@ export default component$(() => {
   return (
     <>
       <h2>This is the documentation for the Button</h2>
-      <Button onClick$={$(() => window.alert('hello'))}>CLICK ME</Button>
-      <hr />
-      <Button disabled={true}>CLICK ME</Button>
+      <div className="flex flex-col gap-8 mt-4">
+        <div>
+          <h2>Basic Example</h2>
+          <Button>SIMPLE BUTTON</Button>
+        </div>
+
+        <div>
+          <h2>Attributes</h2>
+          <Button type="button" disabled={true}>DISABLED BUTTON</Button>
+        </div>
+
+        <div>
+          <h2>Events</h2>
+          <Button onClick$={$(() => window.alert('hello'))}>SHOW ALERT</Button>
+        </div>
+      </div>
     </>
   );
 });


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement

# Description

 `ButtonProps` are now typed to `QwikIntrinsicElements['button']` so the  `<Button />` component can be used with all HTMLButton properties
