### PR TITLE
style: rename className in classNames in Card and Tabs components

### DIFF
--- a/packages/daisy/src/components/card/card.tsx
+++ b/packages/daisy/src/components/card/card.tsx
@@ -8,9 +8,9 @@ export type CardProps = HTMLAttributes<HTMLElement>;
 
 export const Card = component$(
   (props: CardProps) => {
-    const { class: className, ...rest } = props;
+    const { class: classNames, ...rest } = props;
     return (
-        <HeadlessCard class={clsq('card bg-base-100 ', className)} {...rest}>
+        <HeadlessCard class={clsq('card bg-base-100 ', classNames)} {...rest}>
           <Slot />
         </HeadlessCard>
     );

--- a/packages/headless/src/components/tabs/tabs.tsx
+++ b/packages/headless/src/components/tabs/tabs.tsx
@@ -133,7 +133,7 @@ interface TabPanelProps {
 
 // Tab Panel implementation
 export const TabPanel = component$(({ ...props }: TabPanelProps) => {
-  const { class: className, ...rest } = props;
+  const { class: classNames, ...rest } = props;
   const contextService = useContext(tabsContext);
   const thisPanelIndex = useSignal(0);
   const isSelected = () =>
@@ -148,7 +148,7 @@ export const TabPanel = component$(({ ...props }: TabPanelProps) => {
       tabIndex={0}
       aria-labelledby={`tab-${thisPanelIndex}`}
       class={`${isSelected() ? 'is-hidden' : ''}${
-        className ? ` ${className}` : ''
+        classNames ? ` ${classNames}` : ''
       }`}
       style={isSelected() ? 'display: block' : 'display: none'}
       {...rest}


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

`className` property is now renamed in `classNames`