### PR TITLE
fix(rating): add useId as key for each RatingIcon

### DIFF
--- a/packages/headless/src/components/rating/rating.tsx
+++ b/packages/headless/src/components/rating/rating.tsx
@@ -40,6 +40,7 @@ export const Rating = component$(
             const Icon = props.icon || DefaultIcon ;
             return (
               <RatingIcon
+                key={useId()}
                 name={`rating-${uniqueId}`}
                 index={i}
                 onChange$={() => onItemClick$(i)}


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

I noticed the RatingIcon component did not have any key property (this was also logged in console)

```
2:54:54 PM [vite] page reload /Users/leonardo/PersProgetti/qwik-ui/packages/headless/src/components/rating/rating.tsx
QWIK ERROR JSXError: Multiple JSX sibling nodes with the same key.
This is likely caused by missing a custom key in a for loop
    at eval (/src/rating_component_qsamuiuvsow.js:45:56)
    at Array.map (<anonymous>)
    at Rating_component_QSAMuIUvsOw (/src/rating_component_qsamuiuvsow.js:43:45)
    at async Promise.all (index 0)
    at async Promise.all (index 1)
    at async Promise.all (index 1)
    at async Promise.all (index 1)
    at async Promise.all (index 1)
    at async Promise.all (index 1)
    at async Promise.all (index 0)
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
