### PR TITLE
docs(coding standards): add missing space in header

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -31,7 +31,7 @@ buttonGroup.tsx
 buttonGroup folder
 ```
 
-###Component conventions
+### Component conventions
 
 - For each component, add a props interface and declare all the props API there. For example:
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Just found a space that was missing while reading the docs :)