### PR TITLE
docs(coding standards): define a coding standard for exposing components' props

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -33,15 +33,46 @@ buttonGroup folder
 
 ### Component conventions
 
-- For each component, add a props interface and declare all the props API there. For example:
+- For each component, export a props type and declare all the props API there.
+
+For **headless** components:
 
 ```ts
-interface TooltipProps {
-  class?: string;
+export type TooltipProps = {
   tip: string;
   type?: ColorTypes;
   position?: Positions;
-}
+};
+```
+
+Note: if you want to include the HTML attributes, you can use the `QwikIntrinsicElements` type from `@builder.io/qwik` package and extend it with the [intersection type](https://www.typescriptlang.org/docs/handbook/2/objects.html#intersection-types).
+
+Example:
+
+```ts
+import { QwikIntrinsicElements } from '@builder.io/qwik';
+
+export type TooltipProps = QwikIntrinsicElements['div'] & {
+  tip: string;
+  type?: ColorTypes;
+  position?: Positions;
+};
+```
+
+For **Daisy, Material and other components variations**, you can define the new props in a new type, named with the component name and the variation as prefix. For example:
+
+```ts
+type DaisyTooltipProps = {
+  size?: 'sm' | 'md';
+};
+```
+
+The final exported type will extend from the headless props type. For example:
+
+```ts
+import { TooltipProps as HeadlessTooltipProps } from '@qwik-ui/headless';
+
+export type TooltipProps = HeadlessTooltipProps & DaisyTooltipProps;
 ```
 
 - Use object destructuring in the component$ declaration on all the props you are going to use. For example:
@@ -71,13 +102,11 @@ return (
 
 ```tsx
 import { component$, QwikIntrinsicElements, Slot } from '@builder.io/qwik';
-import { Button as HeadlessButton } from '@qwik-ui/headless';
+import { Button as HeadlessButton, ButtonProps as ButtonHeadlessProps } from '@qwik-ui/headless';
 import { clsq } from '@qwik-ui/shared';
 
-// This type holds all the HTML attributes (disabled, hidden, ... )
-export type HTMLButtonProps = QwikIntrinsicElements['button'];
-export type DaisyButtonProps = { size?: 'sm' | 'md', ... };
-export type ButtonProps = HTMLButtonProps & DaisyButtonProps;
+type DaisyButtonProps = { size?: 'sm' | 'md', ... };
+export type ButtonProps = ButtonHeadlessProps & DaisyButtonProps;
 
 export const Button = component$(
   ({ size = 'md', class: classNames, ...rest }: ButtonProps) => {


### PR DESCRIPTION
# What is it?

- [x] Docs / tests

# Description

At the current state, there isn't consistency between how components are exposing their props.
Some are using interfaces while others are using types.
Also, when extending from headless, there are different behaviors in how the headless props are extended/redefined and how variant types (e.g. `DaisyTooltipProps`) are defined.
Besides, there's no clear naming convention on exported types/interfaces.

This PR aims to define a clear guideline so that we can refactor the existing components and be more consistent from now on.

The current version is just a proposal, feedback of all kind are welcome!

---

Some extra thoughts I had while writing:
- Why types over interfaces? I think they're easier to handle with intersection types (`&`) rather than with interface extensions.
- How should we define Daisy and Material? I used the word _variation_ but I'm not sure it's the right one, or is it?
- When extending from Headless, do we really need to have an extra Daisy type as described in this proposal? I would say yes as it makes clear what props are new and specific to the variations.
- Should we export the Daisy type? I don't think we need it, as long as the intersection type is exported. Not a big deal anyway.
- Should we keep `ToastProps` for the headless or should we name the type `HeadlessToastProps` even in the headless file? I don't think we need it as when importing it somewhere it's easy to alias it (`import { TooltipProps as HeadlessTooltipProps }`) 