### PR TITLE
fix: deprecated useClientEffect$ and createContext hooks

### DIFF
--- a/apps/website/src/constants.ts
+++ b/apps/website/src/constants.ts
@@ -1,4 +1,4 @@
-import { createContext } from '@builder.io/qwik';
+import { createContextId } from '@builder.io/qwik';
 import { AppState } from './types';
 
-export const APP_STATE = createContext<AppState>('app_state');
+export const APP_STATE = createContextId<AppState>('app_state');

--- a/apps/website/src/routes/layout.tsx
+++ b/apps/website/src/routes/layout.tsx
@@ -2,7 +2,6 @@ import {
   component$,
   Slot,
   useBrowserVisibleTask$,
-  useClientEffect$,
   useContextProvider,
   useStore,
 } from '@builder.io/qwik';

--- a/packages/daisy/src/components/rating/rating.tsx
+++ b/packages/daisy/src/components/rating/rating.tsx
@@ -1,6 +1,6 @@
 import {
   component$,
-  createContext,
+  createContextId,
   useContext,
   useContextProvider,
   useStore,
@@ -17,7 +17,7 @@ export type DaisyRatingProps = {
   mask?: string;
 } & RatingProps;
 
-export const ContextService = createContext<{ mask: string }>('my-context');
+export const ContextService = createContextId<{ mask: string }>('my-context');
 
 export const Rating = component$((props: DaisyRatingProps) => {
   useStyles$(styles);

--- a/packages/headless/src/components/drawer/drawer.tsx
+++ b/packages/headless/src/components/drawer/drawer.tsx
@@ -1,6 +1,6 @@
 import {
   component$,
-  createContext,
+  createContextId,
   Signal,
   Slot,
   useContextProvider,
@@ -13,7 +13,7 @@ export interface DrawerContext {
   randomId: string;
 }
 
-export const drawerContext = createContext<DrawerContext>('DrawerContext');
+export const drawerContext = createContextId<DrawerContext>('DrawerContext');
 
 export interface DrawerProps {
   class?: string;

--- a/packages/headless/src/components/menu/menu.tsx
+++ b/packages/headless/src/components/menu/menu.tsx
@@ -1,12 +1,12 @@
 import {
   $,
   component$,
-  createContext,
+  createContextId,
   QRL,
   QwikKeyboardEvent,
   Signal,
   Slot,
-  useClientEffect$,
+  useBrowserVisibleTask$,
   useContext,
   useContextProvider,
   useId,
@@ -30,7 +30,7 @@ interface MenuContextService {
 
 const MENU_CONTEXT_NAME = 'qui-menu';
 export const quiMenuContext =
-  createContext<MenuContextService>(MENU_CONTEXT_NAME);
+  createContextId<MenuContextService>(MENU_CONTEXT_NAME);
 
 export enum KEYBOARD_KEY_NAME {
   ARROW_UP = 'ArrowUp',
@@ -61,7 +61,7 @@ export const Menu = component$((props: MenuProps) => {
 
   useContextProvider(quiMenuContext, menuContextService);
 
-  useClientEffect$(({ track }) => {
+  useBrowserVisibleTask$(({ track }) => {
     track(() => isExpanded.value);
     if (!isExpanded.value) {
       currentButtonInFocusIndex.value = -1;
@@ -69,7 +69,7 @@ export const Menu = component$((props: MenuProps) => {
     }
   });
 
-  useClientEffect$(() => {
+  useBrowserVisibleTask$(() => {
     const options = container.value?.querySelectorAll<HTMLElement>('button');
     if (options?.length) {
       options.forEach((option) => children.push(option));

--- a/packages/headless/src/components/popover/popover-content.tsx
+++ b/packages/headless/src/components/popover/popover-content.tsx
@@ -1,24 +1,26 @@
-import { component$, Slot, useClientEffect$, useContext, useSignal, useStylesScoped$ } from '@builder.io/qwik';
+import {
+  component$,
+  Slot,
+  useBrowserVisibleTask$,
+  useContext,
+  useSignal,
+  useStylesScoped$,
+} from '@builder.io/qwik';
 import styles from './popover-content.css?inline';
 import { PopoverContext } from './popover-context';
 
-export const PopoverContent = component$(
-  () => {
-    const ref = useSignal<HTMLElement>();
-    const contextService = useContext(PopoverContext);
-    useStylesScoped$(styles);
+export const PopoverContent = component$(() => {
+  const ref = useSignal<HTMLElement>();
+  const contextService = useContext(PopoverContext);
+  useStylesScoped$(styles);
 
-    useClientEffect$(() => {
-      contextService.setOverlayRef$(ref);
-    });
+  useBrowserVisibleTask$(() => {
+    contextService.setOverlayRef$(ref);
+  });
 
-    return (
-      <div
-        ref={ref}
-        class="popover-content">
-        <Slot />
-      </div>
-    );
-  }
-);
-
+  return (
+    <div ref={ref} class="popover-content">
+      <Slot />
+    </div>
+  );
+});

--- a/packages/headless/src/components/popover/popover-context.tsx
+++ b/packages/headless/src/components/popover/popover-context.tsx
@@ -1,10 +1,11 @@
-import { createContext, QRL, Signal } from '@builder.io/qwik';
+import { createContextId, QRL, Signal } from '@builder.io/qwik';
 
-interface PopoverContextProps  {
-  isOpen: boolean,
+interface PopoverContextProps {
+  isOpen: boolean;
   triggerEvent?: 'click' | 'mouseOver';
   // NEW
   setTriggerRef$: QRL<(ref: Signal<HTMLElement | undefined>) => void>;
   setOverlayRef$: QRL<(ref: Signal<HTMLElement | undefined>) => void>;
 }
-export const PopoverContext = createContext<PopoverContextProps>('popover-context');
+export const PopoverContext =
+  createContextId<PopoverContextProps>('popover-context');

--- a/packages/headless/src/components/popover/popover-trigger.tsx
+++ b/packages/headless/src/components/popover/popover-trigger.tsx
@@ -1,30 +1,39 @@
-import { $, component$, Slot, useClientEffect$, useContext, useSignal, useStylesScoped$ } from '@builder.io/qwik';
+import {
+  $,
+  component$,
+  Slot,
+  useBrowserVisibleTask$,
+  useContext,
+  useSignal,
+  useStylesScoped$,
+} from '@builder.io/qwik';
 import { PopoverContext } from './popover-context';
 import styles from './popover-trigger.css?inline';
 
-export const PopoverTrigger = component$(
-  () => {
-    const ref = useSignal<HTMLElement>();
-    const contextService = useContext(PopoverContext);
-    useStylesScoped$(styles);
+export const PopoverTrigger = component$(() => {
+  const ref = useSignal<HTMLElement>();
+  const contextService = useContext(PopoverContext);
+  useStylesScoped$(styles);
 
-    useClientEffect$(() => {
-      contextService.setTriggerRef$(ref);
-    });
+  useBrowserVisibleTask$(() => {
+    contextService.setTriggerRef$(ref);
+  });
 
-    const mouseOverHandler = $(() => {
-      contextService.isOpen = true
-    })
+  const mouseOverHandler = $(() => {
+    contextService.isOpen = true;
+  });
 
-    return (
-      <span
-        ref={ref}
-        class="popover-trigger"
-        onMouseOver$={contextService.triggerEvent === 'mouseOver' ? mouseOverHandler : undefined}
-      >
-        <Slot />
-      </span>
-    );
-  }
-);
-
+  return (
+    <span
+      ref={ref}
+      class="popover-trigger"
+      onMouseOver$={
+        contextService.triggerEvent === 'mouseOver'
+          ? mouseOverHandler
+          : undefined
+      }
+    >
+      <Slot />
+    </span>
+  );
+});

--- a/packages/headless/src/components/popover/popover.tsx
+++ b/packages/headless/src/components/popover/popover.tsx
@@ -1,5 +1,26 @@
-import { $, component$, PropFunction, QwikMouseEvent, Signal, Slot, useClientEffect$, useContextProvider, useSignal, useStore, useTask$, } from '@builder.io/qwik';import { isBrowser } from '@builder.io/qwik/build';
-import { AlignedPlacement, autoUpdate, computePosition, flip, offset, shift, Side, } from '@floating-ui/dom';
+import {
+  $,
+  component$,
+  PropFunction,
+  QwikMouseEvent,
+  Signal,
+  Slot,
+  useBrowserVisibleTask$,
+  useContextProvider,
+  useSignal,
+  useStore,
+  useTask$,
+} from '@builder.io/qwik';
+import { isBrowser } from '@builder.io/qwik/build';
+import {
+  AlignedPlacement,
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+  Side,
+} from '@floating-ui/dom';
 import { PopoverContext } from './popover-context';
 
 interface PopoverProps {
@@ -27,7 +48,7 @@ interface PopoverProps {
   /**
    * Notify a state update to the parent
    */
-  onUpdate$?: PropFunction<(isOpen: boolean) => void>
+  onUpdate$?: PropFunction<(isOpen: boolean) => void>;
 }
 
 export const Popover = component$((props: PopoverProps) => {
@@ -52,7 +73,7 @@ export const Popover = component$((props: PopoverProps) => {
     isOpen: false,
     triggerEvent,
     setTriggerRef$,
-    setOverlayRef$
+    setOverlayRef$,
   });
   useContextProvider(PopoverContext, contextService);
 
@@ -67,38 +88,35 @@ export const Popover = component$((props: PopoverProps) => {
       contentRef.value?.classList.remove('open');
     }
 
-    if (onUpdate$)
-      await onUpdate$(contextService.isOpen)
-  })
+    if (onUpdate$) await onUpdate$(contextService.isOpen);
+  });
 
   /**
    * Open the popover and sync external states
    */
   const openPopover = $(async () => {
-    contextService.isOpen = true
+    contextService.isOpen = true;
 
     if (contentRef) {
       contentRef.value?.classList.add('open');
       contentRef.value?.classList.remove('close');
     }
 
-    if (onUpdate$)
-      await onUpdate$(contextService.isOpen)
-  })
+    if (onUpdate$) await onUpdate$(contextService.isOpen);
+  });
 
   /**
    * Toggle the popover state and emit update
    */
   const togglePopover = $(async () => {
     if (contextService.isOpen) {
-      closePopover()
+      closePopover();
     } else {
       openPopover();
     }
 
-    if (onUpdate$)
-      await onUpdate$(contextService.isOpen)
-  })
+    if (onUpdate$) await onUpdate$(contextService.isOpen);
+  });
 
   /**
    * Initialize popover
@@ -106,67 +124,69 @@ export const Popover = component$((props: PopoverProps) => {
    * It needs to be invoked after the children useClientEffect
    */
   useTask$(({ track }) => {
-    const trigger = track(() => triggerRef.value as Element) ;
+    const trigger = track(() => triggerRef.value as Element);
     const content = track(() => contentRef.value as HTMLElement);
 
     if (isBrowser && trigger && content) {
-       autoUpdate(trigger, content, () => {
+      autoUpdate(trigger, content, () => {
         computePosition(trigger, content, {
           middleware: [flip(), shift(), offset(props.offset || 0)],
           placement: props.placement,
-        })
-          .then(({x, y}) => {
-            Object.assign(content.style, {
-              left: `${x}px`,
-              top: `${y}px`,
-            });
+        }).then(({ x, y }) => {
+          Object.assign(content.style, {
+            left: `${x}px`,
+            top: `${y}px`,
           });
-      })
+        });
+      });
 
       // Open popover after initialization
       if (props.isOpen) {
-        openPopover()
+        openPopover();
       }
     }
-
   });
 
   /**
    * Sync isOpen external property with internal context
    * NOTE: useful when the popover status is controlled from the outside
    */
-  useClientEffect$(({ track }) => {
+  useBrowserVisibleTask$(({ track }) => {
     track(() => props.isOpen);
     contextService.isOpen = !!props.isOpen;
-  })
+  });
 
   /**
    * Watch isOpen context property
    * and apply CSS classes to show and hide the Popover Content
    */
-  useClientEffect$(({ track }) => {
+  useBrowserVisibleTask$(({ track }) => {
     track(() => contextService.isOpen);
     if (!triggerRef.value || !contentRef.value) return;
 
     if (contextService.isOpen) {
-      openPopover()
+      openPopover();
     } else {
-      closePopover()
+      closePopover();
     }
-  })
+  });
 
   /**
    * clickOutsideHandler
    */
   const clickHandler = $((e: QwikMouseEvent) => {
     // if the popover content is clicked: do nothing
-    const isContentClicked = contentRef.value?.contains(e.target as HTMLElement);
+    const isContentClicked = contentRef.value?.contains(
+      e.target as HTMLElement
+    );
     if (isContentClicked) {
       return;
     }
 
     // if the trigger is Clicked
-    const isTriggerClicked = triggerRef.value?.contains(e.target as HTMLElement);
+    const isTriggerClicked = triggerRef.value?.contains(
+      e.target as HTMLElement
+    );
     if (isTriggerClicked && triggerEvent === 'click') {
       // toggle if triggered by 'click'
       togglePopover();
@@ -175,14 +195,11 @@ export const Popover = component$((props: PopoverProps) => {
       if (disableClickOutSide) return;
       closePopover();
     }
-  })
+  });
 
   return (
-    <span
-      ref={wrapperRef}
-      document:onClick$={clickHandler}
-    >
+    <span ref={wrapperRef} document:onClick$={clickHandler}>
       <Slot />
     </span>
-  )
+  );
 });

--- a/packages/headless/src/components/select/select.tsx
+++ b/packages/headless/src/components/select/select.tsx
@@ -1,6 +1,6 @@
 import {
   component$,
-  createContext,
+  createContextId,
   useContext,
   useContextProvider,
   Slot,
@@ -22,7 +22,7 @@ interface SelectRootContextService {
 }
 
 export const selectContext =
-  createContext<SelectRootContextService>('select-root');
+  createContextId<SelectRootContextService>('select-root');
 
 interface StyleProps {
   class?: string;

--- a/packages/headless/src/components/tabs/tabs.tsx
+++ b/packages/headless/src/components/tabs/tabs.tsx
@@ -1,7 +1,7 @@
 import {
   $,
   component$,
-  createContext,
+  createContextId,
   PropFunction,
   QRL,
   Signal,
@@ -22,7 +22,7 @@ interface TabsContext {
   behavior: Behavior;
 }
 
-export const tabsContext = createContext<TabsContext>('tabList');
+export const tabsContext = createContextId<TabsContext>('tabList');
 
 export interface TabsProps {
   behavior?: Behavior;

--- a/packages/headless/src/components/tooltip/tooltip.tsx
+++ b/packages/headless/src/components/tooltip/tooltip.tsx
@@ -2,7 +2,7 @@ import {
   $,
   component$,
   Slot,
-  useClientEffect$,
+  useBrowserVisibleTask$,
   useId,
   useOnWindow,
   useSignal,
@@ -71,7 +71,7 @@ export const Tooltip = component$(
       })
     );
 
-    useClientEffect$(({ track }) => {
+    useBrowserVisibleTask$(({ track }) => {
       const state = track(() => stateSignal.value);
       if (state === 'unpositioned') {
         // run auto update


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
Fix all occurrence for useClientEffect$ and createContext which are now considered deprecated hooks

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
