### PR TITLE
fix(global.css): set background-color to header

### DIFF
--- a/apps/website/src/global.css
+++ b/apps/website/src/global.css
@@ -35,3 +35,7 @@ body {
   grid-template-columns: 25% auto;
   grid-template-areas: 'sidebar  content';
 }
+
+header {
+  background-color: var(--color-bg) !important;
+}


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Set the background color to the header based on the selected theme.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. The header has no background yet

# Screenshots/Demo

<img width="1920" alt="Screen Shot 2023-02-23 at 8 13 49 AM" src="https://user-images.githubusercontent.com/38874570/220800464-cba253ad-65fd-4527-9e62-b37ed37dc5e5.png">

<img width="1920" alt="Screen Shot 2023-02-23 at 8 14 11 AM" src="https://user-images.githubusercontent.com/38874570/220800478-8ebae285-c4be-4fb2-9823-4cae054d2aad.png">

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
