### PR TITLE
build: bump qwik-nx to v0.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib-types
 
 # Development
 node_modules
+migrations.json
 
 # Cache
 .cache

--- a/apps/website/project.json
+++ b/apps/website/project.json
@@ -5,33 +5,20 @@
   "sourceRoot": "apps/website/src",
   "targets": {
     "build": {
-      "executor": "@nrwl/vite:build",
+      "executor": "qwik-nx:build",
       "options": {
-        "outputPath": "dist/apps/website",
-        "configFile": "apps/website/vite.config.ts"
-      }
-    },
-    "build-ssr": {
-      "executor": "@nrwl/vite:build",
-      "defaultConfiguration": "preview",
-      "options": {
+        "runSequence": ["website:build.client", "website:build.ssr"],
         "outputPath": "dist/apps/website"
       },
       "configurations": {
-        "preview": {
-          "ssr": "src/entry.preview.tsx",
-          "mode": "production"
-        }
-      },
-      "dependsOn": ["build"]
+        "preview": {}
+      }
     },
     "preview": {
-      "executor": "nx:run-commands",
+      "executor": "@nrwl/vite:preview-server",
       "options": {
-        "command": "vite preview",
-        "cwd": "apps/website"
-      },
-      "dependsOn": ["build-ssr"]
+        "buildTarget": "website:build"
+      }
     },
     "test": {
       "executor": "@nrwl/vite:test",
@@ -43,23 +30,33 @@
     },
     "serve": {
       "executor": "@nrwl/vite:dev-server",
-      "defaultConfiguration": "development",
       "options": {
-        "buildTarget": "website:build",
+        "buildTarget": "website:build.client",
         "mode": "ssr"
-      },
-      "configurations": {
-        "development": {
-          "buildTarget": "website:build:development",
-          "hmr": true
-        },
-        "production": {
-          "buildTarget": "website:build:production",
-          "hmr": false
-        }
       }
     },
-    "serveDebug": {
+    "build.client": {
+      "executor": "@nrwl/vite:build",
+      "options": {
+        "outputPath": "dist/apps/website",
+        "configFile": "apps/website/vite.config.ts"
+      }
+    },
+    "build.ssr": {
+      "executor": "@nrwl/vite:build",
+      "defaultConfiguration": "preview",
+      "options": {
+        "outputPath": "dist/apps/website"
+      },
+      "configurations": {
+        "preview": {
+          "ssr": "src/entry.preview.tsx",
+          "mode": "production"
+        }
+      },
+      "dependsOn": []
+    },
+    "serve.debug": {
       "executor": "nx:run-commands",
       "options": {
         "command": "node --inspect-brk ../..//node_modules/vite/bin/vite.js --mode ssr --force",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "postcss": "^8.4.21",
     "prettier": "2.8.4",
     "pretty-quick": "^3.1.3",
-    "qwik-nx": "0.10.0",
+    "qwik-nx": "0.11.1",
     "sass": "1.58.1",
     "storybook": "7.0.0-beta.30",
     "storybook-framework-qwik": "0.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
       postcss: ^8.4.21
       prettier: 2.8.4
       pretty-quick: ^3.1.3
-      qwik-nx: 0.10.0
+      qwik-nx: 0.11.1
       sass: 1.58.1
       storybook: 7.0.0-beta.30
       storybook-framework-qwik: 0.0.8
@@ -126,7 +126,7 @@ importers:
       postcss: 8.4.21
       prettier: 2.8.4
       pretty-quick: 3.1.3_prettier@2.8.4
-      qwik-nx: 0.10.0_xhmadf5sj4kmjus6acqdwmoa4i
+      qwik-nx: 0.11.1_xhmadf5sj4kmjus6acqdwmoa4i
       sass: 1.58.1
       storybook: 7.0.0-beta.30
       storybook-framework-qwik: 0.0.8_yseiwrxv756o467owc5yfzbuia
@@ -17934,16 +17934,16 @@ packages:
     engines: { node: '>=10' }
     dev: true
 
-  /qwik-nx/0.10.0_xhmadf5sj4kmjus6acqdwmoa4i:
+  /qwik-nx/0.11.1_xhmadf5sj4kmjus6acqdwmoa4i:
     resolution:
       {
-        integrity: sha512-xqMfBfpU7fCU7wbqPlBCioVcNGu8ZTn12ElI62kA13nAol7DKV4vQUkMsjCsd4OD7yVUBP15SKCB2LfFa09OTQ==,
+        integrity: sha512-XX5sJ78NqJlKRamqYar/1SJSaYyfmcj4LpX9x+dZcdUA+I+S1KXNqQ7fQ4s7zl2oVwsVzOjfcBrIiag9op44lw==,
       }
     peerDependencies:
       '@builder.io/qwik': ^0.17.0
-      '@nrwl/vite': ~15.6.0
+      '@nrwl/vite': ~15.7.2
       '@playwright/test': ^1.30.0
-      tslib: 2.4.1
+      tslib: ^2.3.0
       undici: ^5.18.0
       vite: ^4.0.0
       vitest: ^0.25.0


### PR DESCRIPTION
Bumped qwik-nx to the latest version and ran migration for the project.json. Apart from the migration also updated preview target to use @nrwl/vite:preview-server executor