### PR TITLE
fix(toggle component): renamed prop & change funcionality in Toggle

### DIFF
--- a/apps/website/src/routes/docs/daisy/toggle/index.tsx
+++ b/apps/website/src/routes/docs/daisy/toggle/index.tsx
@@ -7,7 +7,7 @@ export default component$(() => {
     <>
       <h2>This is the documentation for the Toggle</h2>
       <Toggle
-        checked={toggleChecked.value}
+        pressed={toggleChecked.value}
         onClick$={() => {
           toggleChecked.value = !toggleChecked.value;
         }}

--- a/packages/daisy/src/components/toggle/toggle.tsx
+++ b/packages/daisy/src/components/toggle/toggle.tsx
@@ -1,22 +1,21 @@
-import { component$, PropFunction, QwikMouseEvent } from '@builder.io/qwik';
-import { Toggle as HeadlessToggle } from '@qwik-ui/headless';
+import { component$ } from '@builder.io/qwik';
+import {
+  Toggle as HeadlessToggle,
+  ToggleProps as HeadlessToggleProps,
+} from '@qwik-ui/headless';
 
-interface ToggleProps {
+export interface ToggleProps extends HeadlessToggleProps {
   class?: string;
-  checked: boolean;
   label?: string;
-  onClick$: PropFunction<(evt: QwikMouseEvent) => void>;
 }
 
-export const Toggle = component$(
-  ({ checked, label, ...props }: ToggleProps) => {
-    return (
-      <div class="form-control">
-        <label class="label cursor-pointer">
-          {label && <span class="label-text">{label}</span>}
-          <HeadlessToggle class="toggle" pressed={checked} {...props} />
-        </label>
-      </div>
-    );
-  }
-);
+export const Toggle = component$(({ label, ...props }: ToggleProps) => {
+  return (
+    <div class="form-control">
+      <label class="label cursor-pointer">
+        {label && <span class="label-text">{label}</span>}
+        <HeadlessToggle class="toggle" {...props} />
+      </label>
+    </div>
+  );
+});

--- a/packages/headless/src/components/toggle/toggle.tsx
+++ b/packages/headless/src/components/toggle/toggle.tsx
@@ -5,8 +5,7 @@ import {
   useSignal,
 } from '@builder.io/qwik';
 
-interface ToggleProps {
-  value?: string;
+export interface ToggleProps {
   disabled?: boolean;
   /**
    * The controlled state of the toggle.
@@ -40,6 +39,7 @@ export const Toggle = component$((props: ToggleProps) => {
       aria-pressed={pressedState.value}
       data-state={pressedState.value ? 'on' : 'off'}
       data-disabled={disabled ? '' : undefined}
+      checked={pressedState.value}
       onClick$={(event: QwikMouseEvent<HTMLInputElement>) => {
         if (!disabled) {
           pressedState.value = !pressedState.value;


### PR DESCRIPTION
# What is it?

- [ ] Feature/enhancement
- [x] Bug
- [ ] Docs/tests

# Description

I had a few issues implementing the toggle component on the pagination docs
Described at [#209](https://github.com/qwikifiers/qwik-ui/issues/209)

- HeadlessToggle expected a prop `pressed` and the DaisyToggle received `checked` and passed it as `pressed`, I renamed it.
- DaisyToggleProps interface didn't extend HeadlessToggleProps
- `pressed` and `defaultPressed` didn't were always initially `false`.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix/functionality
