### PR TITLE
feat(component): add new Breadcrumb component

### DIFF
--- a/apps/website/src/components/menu/menu.tsx
+++ b/apps/website/src/components/menu/menu.tsx
@@ -15,6 +15,10 @@ export const Menu = component$<Props>(({ onClose$ }) => {
       label: 'Accordion',
       path: `/docs/${appState.theme.toLowerCase()}/accordion`,
     },
+    {
+      label: 'Breadcrumb',
+      path: `/docs/${appState.theme.toLowerCase()}/breadcrumb`,
+    },
     { label: 'Button', path: `/docs/${appState.theme.toLowerCase()}/button` },
     {
       label: 'ButtonGroup',

--- a/apps/website/src/routes/docs/daisy/breadcrumb/BreadcrumbWrapper.tsx
+++ b/apps/website/src/routes/docs/daisy/breadcrumb/BreadcrumbWrapper.tsx
@@ -1,0 +1,12 @@
+import { component$, Slot } from '@builder.io/qwik';
+
+export default component$((props: { title?: string; class?: string }) => {
+  return (
+    <div class={props.class || ''}>
+      {props.title && <h1 class="mt-8 mb-4">{props.title}</h1>}
+      <div class="dark:bg-slate-900 bg-slate-200 rounded p-3">
+        <Slot />
+      </div>
+    </div>
+  );
+});

--- a/apps/website/src/routes/docs/daisy/breadcrumb/PathIcon.tsx
+++ b/apps/website/src/routes/docs/daisy/breadcrumb/PathIcon.tsx
@@ -1,0 +1,19 @@
+import { component$ } from '@builder.io/qwik';
+
+export default component$(() => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      class="w-4 h-4 mr-2 stroke-current"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+      ></path>
+    </svg>
+  );
+});

--- a/apps/website/src/routes/docs/daisy/breadcrumb/index.tsx
+++ b/apps/website/src/routes/docs/daisy/breadcrumb/index.tsx
@@ -33,34 +33,33 @@ export default component$(() => {
 
       <BreadcrumbWrapper title="Breadcrumb Example">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => (
-            <BreadcrumbItem>{itemBreadcrumb.name}</BreadcrumbItem>
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
+            <BreadcrumbItem key={index}>{itemBreadcrumb.name}</BreadcrumbItem>
           ))}
         </Breadcrumb>
       </BreadcrumbWrapper>
 
       <BreadcrumbWrapper title="Breadcrumb with Icon Example">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => {
-            return (
-              <BreadcrumbItem>
-                <a
-                  href={`${itemBreadcrumb.path}`}
-                  class="inline-flex items-center hover:underline"
-                >
-                  <PathIcon />
-                  <span>{itemBreadcrumb.name}</span>
-                </a>
-              </BreadcrumbItem>
-            );
-          })}
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
+            <BreadcrumbItem key={index}>
+              <a
+                href={`${itemBreadcrumb.path}`}
+                class="inline-flex items-center hover:underline"
+              >
+                <PathIcon />
+                <span>{itemBreadcrumb.name}</span>
+              </a>
+            </BreadcrumbItem>
+          ))}
         </Breadcrumb>
       </BreadcrumbWrapper>
 
       <BreadcrumbWrapper title="Breadcrumb with Active Example">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => (
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
             <BreadcrumbItem
+              key={index}
               class={itemBreadcrumb.path === url.pathname ? 'text-primary' : ''}
             >
               {itemBreadcrumb.name}
@@ -71,21 +70,19 @@ export default component$(() => {
 
       <BreadcrumbWrapper class="mt-4">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => {
-            return (
-              <BreadcrumbItem>
-                <a
-                  href={`${itemBreadcrumb.path}`}
-                  class={`inline-flex items-center hover:underline ${
-                    itemBreadcrumb.path === url.pathname ? 'text-primary' : ''
-                  }`}
-                >
-                  <PathIcon />
-                  <span>{itemBreadcrumb.name}</span>
-                </a>
-              </BreadcrumbItem>
-            );
-          })}
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
+            <BreadcrumbItem key={index}>
+              <a
+                href={`${itemBreadcrumb.path}`}
+                class={`inline-flex items-center hover:underline ${
+                  itemBreadcrumb.path === url.pathname ? 'text-primary' : ''
+                }`}
+              >
+                <PathIcon />
+                <span>{itemBreadcrumb.name}</span>
+              </a>
+            </BreadcrumbItem>
+          ))}
         </Breadcrumb>
       </BreadcrumbWrapper>
     </div>

--- a/apps/website/src/routes/docs/daisy/breadcrumb/index.tsx
+++ b/apps/website/src/routes/docs/daisy/breadcrumb/index.tsx
@@ -1,0 +1,93 @@
+import { component$ } from '@builder.io/qwik';
+import { useLocation } from '@builder.io/qwik-city';
+import { Breadcrumb, BreadcrumbItem } from '@qwik-ui/theme-daisy';
+import BreadcrumbWrapper from './BreadcrumbWrapper';
+import PathIcon from './PathIcon';
+
+interface BreadcrumbPath {
+  name: string;
+  path: string;
+}
+
+export default component$(() => {
+  const { url } = useLocation();
+
+  const breadcrumbPath: BreadcrumbPath[] = url.pathname
+    .split('/')
+    .filter((path) => path)
+    .map((path, indexPath, arrPath) => {
+      return {
+        name: path,
+        path:
+          indexPath > 0
+            ? `/${arrPath
+                .filter((_, indexPath2) => indexPath2 < indexPath)
+                .join('/')}/${arrPath[indexPath]}/`
+            : `/${path}/`,
+      };
+    });
+
+  return (
+    <div>
+      <h2>This is the documentation for the Breadcrumb</h2>
+
+      <BreadcrumbWrapper title="Breadcrumb Example">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => (
+            <BreadcrumbItem>{itemBreadcrumb.name}</BreadcrumbItem>
+          ))}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+
+      <BreadcrumbWrapper title="Breadcrumb with Icon Example">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => {
+            return (
+              <BreadcrumbItem>
+                <a
+                  href={`${itemBreadcrumb.path}`}
+                  class="inline-flex items-center hover:underline"
+                >
+                  <PathIcon />
+                  <span>{itemBreadcrumb.name}</span>
+                </a>
+              </BreadcrumbItem>
+            );
+          })}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+
+      <BreadcrumbWrapper title="Breadcrumb with Active Example">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => (
+            <BreadcrumbItem
+              class={itemBreadcrumb.path === url.pathname ? 'text-primary' : ''}
+            >
+              {itemBreadcrumb.name}
+            </BreadcrumbItem>
+          ))}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+
+      <BreadcrumbWrapper class="mt-4">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => {
+            return (
+              <BreadcrumbItem>
+                <a
+                  href={`${itemBreadcrumb.path}`}
+                  class={`inline-flex items-center hover:underline ${
+                    itemBreadcrumb.path === url.pathname ? 'text-primary' : ''
+                  }`}
+                >
+                  <PathIcon />
+                  <span>{itemBreadcrumb.name}</span>
+                </a>
+              </BreadcrumbItem>
+            );
+          })}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+    </div>
+  );
+});

--- a/apps/website/src/routes/docs/headless/breadcrumb/BreadcrumbWrapper.css
+++ b/apps/website/src/routes/docs/headless/breadcrumb/BreadcrumbWrapper.css
@@ -1,0 +1,18 @@
+[data-theme='light'] {
+  --wrapper-color-bg: rgb(226 232 240);
+}
+
+[data-theme='dark'] {
+  --wrapper-color-bg: rgb(15 23 42);
+}
+
+.wrapper__title {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.wrapper__content {
+  background-color: var(--wrapper-color-bg) !important;
+  border-radius: 0.25rem;
+  padding: 0.75rem;
+}

--- a/apps/website/src/routes/docs/headless/breadcrumb/BreadcrumbWrapper.tsx
+++ b/apps/website/src/routes/docs/headless/breadcrumb/BreadcrumbWrapper.tsx
@@ -1,0 +1,12 @@
+import { component$, Slot } from '@builder.io/qwik';
+
+export default component$((props: { title?: string; class?: string }) => {
+  return (
+    <div class={props.class || ''}>
+      {props.title && <h1 class="mt-8 mb-4">{props.title}</h1>}
+      <div class="dark:bg-slate-900 bg-slate-200 rounded p-3">
+        <Slot />
+      </div>
+    </div>
+  );
+});

--- a/apps/website/src/routes/docs/headless/breadcrumb/BreadcrumbWrapper.tsx
+++ b/apps/website/src/routes/docs/headless/breadcrumb/BreadcrumbWrapper.tsx
@@ -1,10 +1,17 @@
-import { component$, Slot } from '@builder.io/qwik';
+import { component$, HTMLAttributes, Slot, useStyles$ } from '@builder.io/qwik';
+import style from './BreadcrumbWrapper.css?inline';
 
-export default component$((props: { title?: string; class?: string }) => {
+interface BreadcrumbWrapperProps extends HTMLAttributes<HTMLElement> {
+  title?: string;
+}
+
+export default component$(({ title, ...rest }: BreadcrumbWrapperProps) => {
+  useStyles$(style);
+
   return (
-    <div class={props.class || ''}>
-      {props.title && <h1 class="mt-8 mb-4">{props.title}</h1>}
-      <div class="dark:bg-slate-900 bg-slate-200 rounded p-3">
+    <div {...rest}>
+      {title && <h1 class="wrapper__title">{title}</h1>}
+      <div class="wrapper__content">
         <Slot />
       </div>
     </div>

--- a/apps/website/src/routes/docs/headless/breadcrumb/PathIcon.tsx
+++ b/apps/website/src/routes/docs/headless/breadcrumb/PathIcon.tsx
@@ -1,0 +1,19 @@
+import { component$ } from '@builder.io/qwik';
+
+export default component$(() => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      class="w-4 h-4 mr-2 stroke-current"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+      ></path>
+    </svg>
+  );
+});

--- a/apps/website/src/routes/docs/headless/breadcrumb/PathIcon.tsx
+++ b/apps/website/src/routes/docs/headless/breadcrumb/PathIcon.tsx
@@ -1,13 +1,12 @@
-import { component$ } from '@builder.io/qwik';
+import { component$, useStylesScoped$ } from '@builder.io/qwik';
 
 export default component$(() => {
+  useStylesScoped$(`
+    svg { width: 1rem;height:1rem;stroke:currentColor;margin-right:0.5rem; }
+  `);
+
   return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      class="w-4 h-4 mr-2 stroke-current"
-    >
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
       <path
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/apps/website/src/routes/docs/headless/breadcrumb/index.css
+++ b/apps/website/src/routes/docs/headless/breadcrumb/index.css
@@ -1,0 +1,17 @@
+.breadcrumb-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.breadcrumb-item:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb-item--hovered:hover {
+  text-decoration: underline;
+  color: hsl(258.89 94.378% 51.176%);
+}
+
+.breadcrumb-item--active {
+  color: hsl(258.89 94.378% 51.176%);
+}

--- a/apps/website/src/routes/docs/headless/breadcrumb/index.tsx
+++ b/apps/website/src/routes/docs/headless/breadcrumb/index.tsx
@@ -1,8 +1,9 @@
-import { component$ } from '@builder.io/qwik';
+import { component$, useStylesScoped$ } from '@builder.io/qwik';
 import { useLocation } from '@builder.io/qwik-city';
 import { Breadcrumb, BreadcrumbItem } from '@qwik-ui/headless';
 import BreadcrumbWrapper from './BreadcrumbWrapper';
 import PathIcon from './PathIcon';
+import style from './index.css?inline';
 
 interface BreadcrumbPath {
   name: string;
@@ -27,41 +28,43 @@ export default component$(() => {
       };
     });
 
+  useStylesScoped$(style);
+
   return (
     <div>
       <h2>This is the documentation for the Breadcrumb</h2>
 
       <BreadcrumbWrapper title="Breadcrumb Example">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => (
-            <BreadcrumbItem>{itemBreadcrumb.name}</BreadcrumbItem>
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
+            <BreadcrumbItem key={index}>{itemBreadcrumb.name}</BreadcrumbItem>
           ))}
         </Breadcrumb>
       </BreadcrumbWrapper>
 
       <BreadcrumbWrapper title="Breadcrumb with Icon Example">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => {
-            return (
-              <BreadcrumbItem>
-                <a
-                  href={`${itemBreadcrumb.path}`}
-                  class="inline-flex items-center hover:underline"
-                >
-                  <PathIcon />
-                  <span>{itemBreadcrumb.name}</span>
-                </a>
-              </BreadcrumbItem>
-            );
-          })}
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
+            <BreadcrumbItem key={index}>
+              <a href={`${itemBreadcrumb.path}`} class="breadcrumb-item">
+                <PathIcon />
+                <span>{itemBreadcrumb.name}</span>
+              </a>
+            </BreadcrumbItem>
+          ))}
         </Breadcrumb>
       </BreadcrumbWrapper>
 
       <BreadcrumbWrapper title="Breadcrumb with Active Example">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => (
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
             <BreadcrumbItem
-              class={itemBreadcrumb.path === url.pathname ? 'text-primary' : ''}
+              key={index}
+              class={
+                itemBreadcrumb.path === url.pathname
+                  ? 'breadcrumb-item--active'
+                  : ''
+              }
             >
               {itemBreadcrumb.name}
             </BreadcrumbItem>
@@ -69,33 +72,33 @@ export default component$(() => {
         </Breadcrumb>
       </BreadcrumbWrapper>
 
-      <BreadcrumbWrapper class="mt-4">
+      <BreadcrumbWrapper style={{ marginTop: '1rem' }}>
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => {
-            return (
-              <BreadcrumbItem>
-                <a
-                  href={`${itemBreadcrumb.path}`}
-                  class={`inline-flex items-center hover:underline ${
-                    itemBreadcrumb.path === url.pathname ? 'text-primary' : ''
-                  }`}
-                >
-                  <PathIcon />
-                  <span>{itemBreadcrumb.name}</span>
-                </a>
-              </BreadcrumbItem>
-            );
-          })}
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
+            <BreadcrumbItem key={index}>
+              <a
+                href={`${itemBreadcrumb.path}`}
+                class={`breadcrumb-item ${
+                  itemBreadcrumb.path === url.pathname
+                    ? 'breadcrumb-item--active'
+                    : ''
+                }`}
+              >
+                <PathIcon />
+                <span>{itemBreadcrumb.name}</span>
+              </a>
+            </BreadcrumbItem>
+          ))}
         </Breadcrumb>
       </BreadcrumbWrapper>
 
       <BreadcrumbWrapper title="Breadcrumb with Custom Divider Example">
         <Breadcrumb>
-          {breadcrumbPath.map((itemBreadcrumb) => (
-            <BreadcrumbItem divider="→">
+          {breadcrumbPath.map((itemBreadcrumb, index) => (
+            <BreadcrumbItem key={index} divider="→">
               <a
                 href={`${itemBreadcrumb.path}`}
-                class={`inline-flex items-center hover:underline hover:text-primary`}
+                class="breadcrumb-item--hovered"
               >
                 <span>{itemBreadcrumb.name}</span>
               </a>

--- a/apps/website/src/routes/docs/headless/breadcrumb/index.tsx
+++ b/apps/website/src/routes/docs/headless/breadcrumb/index.tsx
@@ -1,0 +1,108 @@
+import { component$ } from '@builder.io/qwik';
+import { useLocation } from '@builder.io/qwik-city';
+import { Breadcrumb, BreadcrumbItem } from '@qwik-ui/headless';
+import BreadcrumbWrapper from './BreadcrumbWrapper';
+import PathIcon from './PathIcon';
+
+interface BreadcrumbPath {
+  name: string;
+  path: string;
+}
+
+export default component$(() => {
+  const { url } = useLocation();
+
+  const breadcrumbPath: BreadcrumbPath[] = url.pathname
+    .split('/')
+    .filter((path) => path)
+    .map((path, indexPath, arrPath) => {
+      return {
+        name: path,
+        path:
+          indexPath > 0
+            ? `/${arrPath
+                .filter((_, indexPath2) => indexPath2 < indexPath)
+                .join('/')}/${arrPath[indexPath]}/`
+            : `/${path}/`,
+      };
+    });
+
+  return (
+    <div>
+      <h2>This is the documentation for the Breadcrumb</h2>
+
+      <BreadcrumbWrapper title="Breadcrumb Example">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => (
+            <BreadcrumbItem>{itemBreadcrumb.name}</BreadcrumbItem>
+          ))}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+
+      <BreadcrumbWrapper title="Breadcrumb with Icon Example">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => {
+            return (
+              <BreadcrumbItem>
+                <a
+                  href={`${itemBreadcrumb.path}`}
+                  class="inline-flex items-center hover:underline"
+                >
+                  <PathIcon />
+                  <span>{itemBreadcrumb.name}</span>
+                </a>
+              </BreadcrumbItem>
+            );
+          })}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+
+      <BreadcrumbWrapper title="Breadcrumb with Active Example">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => (
+            <BreadcrumbItem
+              class={itemBreadcrumb.path === url.pathname ? 'text-primary' : ''}
+            >
+              {itemBreadcrumb.name}
+            </BreadcrumbItem>
+          ))}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+
+      <BreadcrumbWrapper class="mt-4">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => {
+            return (
+              <BreadcrumbItem>
+                <a
+                  href={`${itemBreadcrumb.path}`}
+                  class={`inline-flex items-center hover:underline ${
+                    itemBreadcrumb.path === url.pathname ? 'text-primary' : ''
+                  }`}
+                >
+                  <PathIcon />
+                  <span>{itemBreadcrumb.name}</span>
+                </a>
+              </BreadcrumbItem>
+            );
+          })}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+
+      <BreadcrumbWrapper title="Breadcrumb with Custom Divider Example">
+        <Breadcrumb>
+          {breadcrumbPath.map((itemBreadcrumb) => (
+            <BreadcrumbItem divider="→">
+              <a
+                href={`${itemBreadcrumb.path}`}
+                class={`inline-flex items-center hover:underline hover:text-primary`}
+              >
+                <span>{itemBreadcrumb.name}</span>
+              </a>
+            </BreadcrumbItem>
+          ))}
+        </Breadcrumb>
+      </BreadcrumbWrapper>
+    </div>
+  );
+});

--- a/packages/daisy/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/packages/daisy/src/components/breadcrumb/breadcrumb-item.tsx
@@ -1,0 +1,14 @@
+import { component$, HTMLAttributes, Slot } from '@builder.io/qwik';
+import { BreadcrumbItem as HeadlessBreadcrumbItem } from '@qwik-ui/headless';
+
+type BreadcrumbProps = HTMLAttributes<HTMLElement>;
+
+export const BreadcrumbItem = component$((props: BreadcrumbProps) => {
+  return (
+    <li>
+      <HeadlessBreadcrumbItem {...props}>
+        <Slot />
+      </HeadlessBreadcrumbItem>
+    </li>
+  );
+});

--- a/packages/daisy/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/daisy/src/components/breadcrumb/breadcrumb.tsx
@@ -1,0 +1,17 @@
+import { component$, HTMLAttributes, Slot } from '@builder.io/qwik';
+import { Breadcrumb as HeadlessBreadcrumb } from '@qwik-ui/headless';
+import { clsq } from '@qwik-ui/shared';
+
+type BreadcrumbProps = HTMLAttributes<HTMLElement>;
+
+export const Breadcrumb = component$((props: BreadcrumbProps) => {
+  const { class: classNames, ...rest } = props;
+
+  return (
+    <HeadlessBreadcrumb class={clsq('breadcrumbs ', classNames)} {...rest}>
+      <ul>
+        <Slot />
+      </ul>
+    </HeadlessBreadcrumb>
+  );
+});

--- a/packages/daisy/src/components/breadcrumb/index.ts
+++ b/packages/daisy/src/components/breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export * from './breadcrumb';
+export * from './breadcrumb-item';

--- a/packages/daisy/src/index.ts
+++ b/packages/daisy/src/index.ts
@@ -14,3 +14,4 @@ export * from './components/tooltip/tooltip';
 export * from './components/pagination/pagination';
 export * from './components/ratio/radio';
 export * from './components/slider/slider';
+export * from './components/breadcrumb';

--- a/packages/headless/src/components/breadcrumb/breadcrumb-item.css
+++ b/packages/headless/src/components/breadcrumb/breadcrumb-item.css
@@ -1,0 +1,12 @@
+div {
+  display: flex;
+  align-items: center;
+}
+
+div + *:before {
+  content: var(--breadcrumb-divider, '/');
+  padding-left: 0.3rem;
+  padding-right: 0.4rem;
+  display: block;
+  opacity: 0.5;
+}

--- a/packages/headless/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/packages/headless/src/components/breadcrumb/breadcrumb-item.tsx
@@ -1,0 +1,28 @@
+import {
+  component$,
+  HTMLAttributes,
+  Slot,
+  useStyles$,
+  useStylesScoped$,
+} from '@builder.io/qwik';
+import styles from './breadcrumb-item.css?inline';
+import { clsq } from '@qwik-ui/shared';
+
+export interface BreadcrumbItemProps extends HTMLAttributes<HTMLElement> {
+  divider?: string;
+}
+
+export const BreadcrumbItem = component$((props: BreadcrumbItemProps) => {
+  const { style, ...rest } = props;
+
+  useStylesScoped$(styles);
+
+  return (
+    <div
+      style={clsq(`--breadcrumb-divider: "${props.divider || '/'}"`, style)}
+      {...rest}
+    >
+      <Slot />
+    </div>
+  );
+});

--- a/packages/headless/src/components/breadcrumb/breadcrumb.css
+++ b/packages/headless/src/components/breadcrumb/breadcrumb.css
@@ -1,0 +1,6 @@
+div {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  min-height: min-content;
+}

--- a/packages/headless/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/headless/src/components/breadcrumb/breadcrumb.tsx
@@ -1,0 +1,18 @@
+import {
+  component$,
+  HTMLAttributes,
+  Slot,
+  useStylesScoped$,
+} from '@builder.io/qwik';
+import styles from './breadcrumb.css?inline';
+
+export type BreadcrumbProps = HTMLAttributes<HTMLElement>;
+
+export const Breadcrumb = component$((props: BreadcrumbProps) => {
+  useStylesScoped$(styles);
+  return (
+    <div {...props}>
+      <Slot />
+    </div>
+  );
+});

--- a/packages/headless/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/headless/src/components/breadcrumb/breadcrumb.tsx
@@ -10,6 +10,7 @@ export type BreadcrumbProps = HTMLAttributes<HTMLElement>;
 
 export const Breadcrumb = component$((props: BreadcrumbProps) => {
   useStylesScoped$(styles);
+
   return (
     <div {...props}>
       <Slot />

--- a/packages/headless/src/components/breadcrumb/index.ts
+++ b/packages/headless/src/components/breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export * from './breadcrumb';
+export * from './breadcrumb-item';

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -16,3 +16,4 @@ export * from './components/tooltip/tooltip';
 export * as Select from './components/select/select';
 export * from './components/slider';
 export * from './components/radio/radio';
+export * from './components/breadcrumb';


### PR DESCRIPTION
Add Breadcrumb component (headless and daisy) and Breadcrumb component  website docs

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Add a new Breadcrumb component (headless & daisy) 

# Screenshots/Demo
<img width="1186" alt="Screen Shot 2023-02-26 at 12 46 50 AM" src="https://user-images.githubusercontent.com/38874570/221371909-3d368121-a8d2-4224-8aa1-82e8449033c1.png">

<img width="1193" alt="Screen Shot 2023-02-26 at 12 47 03 AM" src="https://user-images.githubusercontent.com/38874570/221371904-40b456c7-4b23-426e-baec-c7d633bd299d.png">

<!-- Add your screenshots here -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
