### PR TITLE
refactor(components): change primitives to lite components

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,8 +1,13 @@
 # Qwik-UI Coding Standards
 
+## Primitives package
+
+In the primitive package you put only primitive elements. What is a primitive element? A Qwik element wrapper that wraps a regular Html element and doesn't add any behavior to it in particular. All these elements should be implemented as [lite components](https://qwik.builder.io/docs/components/lite-components), if that is possible (for example, because Checkbox uses an inner state it isn't implemented as a lite component).
+
 ## Headless package CSS style
 
-The goal of this pack is to have a minimal style to be used at will. For the documentation of the headless components we will provide minimal examples style to show them to the end users.
+The goal of this package is to have a minimal style to be used at will. For the documentation of the headless components we will provide minimal examples style to show them to the end users.
+_Pay attention that classes from frameworks such as Tailwind, Daisy, Bootstrap etc. must not leak into the headless package_.
 
 ## Coding practices
 
@@ -83,7 +88,8 @@ export const Tooltip = component$(({ tip, position = 'top', type, ...props}: Too
 });
 ```
 
-- Try to avoid using `useClientEffect$` function. See [Qwik best practices](https://qwik.builder.io/docs/cheat/best-practices/) for the why.
+- Use class and not className when in the JSX and in the component props (if you expect to have a class props part if the component props).
+- Try to avoid using `useBrowserVisibleTask$` function. See [Qwik best practices](https://qwik.builder.io/docs/cheat/best-practices/) for the why.
 - Try to use the Slot element whenever the component can accept children
 - Use array spread on props to allow the component user to send props that override ours. For example:
 

--- a/packages/headless/src/components/action-button/action-button.tsx
+++ b/packages/headless/src/components/action-button/action-button.tsx
@@ -1,0 +1,26 @@
+import type { JSXChildren } from '@builder.io/qwik';
+import { type ActionStore, Form } from '@builder.io/qwik-city';
+import { QwikIntrinsicElements } from '@builder.io/qwik';
+
+export type ActionButtonProps = QwikIntrinsicElements['button'] & {
+  action: ActionStore<any, any>;
+  children: JSXChildren;
+  params?: Record<string, any>;
+};
+
+export const ActionButton = ({
+  action,
+  children,
+  params,
+  ...props
+}: ActionButtonProps) => {
+  return (
+    <Form action={action}>
+      {params &&
+        Object.keys(params).map((key) => (
+          <input type="hidden" name={key} value={params[key]} />
+        ))}
+      <button {...props}>{children}</button>
+    </Form>
+  );
+};

--- a/packages/primitives/src/lib/alert/alert.tsx
+++ b/packages/primitives/src/lib/alert/alert.tsx
@@ -1,11 +1,9 @@
-import { component$, HTMLAttributes, Slot } from '@builder.io/qwik';
+import { HTMLAttributes, JSXChildren } from '@builder.io/qwik';
 
-export type AlertProps = HTMLAttributes<HTMLDivElement>;
+export type AlertProps = HTMLAttributes<HTMLDivElement> & {
+  children: JSXChildren;
+};
 
-export const Alert = component$((props: AlertProps) => {
-  return (
-    <div {...props}>
-      <Slot />
-    </div>
-  );
-});
+export const Alert = ({ children, ...props }: AlertProps) => {
+  return <div {...props}>{children}</div>;
+};

--- a/packages/primitives/src/lib/button/button.tsx
+++ b/packages/primitives/src/lib/button/button.tsx
@@ -1,13 +1,9 @@
-import { component$, QwikIntrinsicElements, Slot } from '@builder.io/qwik';
+import { QwikIntrinsicElements, JSXChildren } from '@builder.io/qwik';
 
-export type ButtonProps = QwikIntrinsicElements['button'];
+export type ButtonProps = QwikIntrinsicElements['button'] & {
+  children: JSXChildren;
+};
 
-export const Button = component$(
-  (props: ButtonProps) => {
-    return (
-      <button {...props}>
-        <Slot />
-      </button>
-    );
-  }
-);
+export const Button = ({ children, ...props }: ButtonProps) => {
+  return <button {...props}>{children}</button>;
+};

--- a/packages/primitives/src/lib/progress/progress.tsx
+++ b/packages/primitives/src/lib/progress/progress.tsx
@@ -1,7 +1,7 @@
-import { component$, QwikIntrinsicElements } from '@builder.io/qwik';
+import { QwikIntrinsicElements } from '@builder.io/qwik';
 
 export type ProgressProps = QwikIntrinsicElements['progress'];
 
-export const Progress = component$((props: ProgressProps) => {
+export const Progress = (props: ProgressProps) => {
   return <progress {...props} />;
-});
+};

--- a/packages/primitives/src/lib/radio/radio.tsx
+++ b/packages/primitives/src/lib/radio/radio.tsx
@@ -1,7 +1,7 @@
-import { component$, QwikIntrinsicElements } from '@builder.io/qwik';
+import { QwikIntrinsicElements } from '@builder.io/qwik';
 
 export type RadioProps = QwikIntrinsicElements['input'];
 
-export const Radio = component$((props: RadioProps) => (
+export const Radio = (props: RadioProps) => (
   <input {...props} type="radio" />
-));
+);

--- a/packages/primitives/src/lib/toast/toast.tsx
+++ b/packages/primitives/src/lib/toast/toast.tsx
@@ -1,5 +1,4 @@
-import { component$ } from '@builder.io/qwik';
-interface ToastProps {
+export type ToastProps = {
   /**
    * The controlled state of the toast.
    */
@@ -7,12 +6,10 @@ interface ToastProps {
   class?: string;
 }
 
-export const Toast = component$(
-  ({ label = 'New Message', ...toastProps }: ToastProps) => {
-    return (
-      <div {...toastProps}>
-        <span>{label}</span>
-      </div>
-    );
-  }
-);
+export const Toast = ({ label = 'New Message', ...toastProps }: ToastProps) => {
+  return (
+    <div {...toastProps}>
+      <span>{label}</span>
+    </div>
+  );
+};

--- a/packages/primitives/src/lib/toggle/toggle.tsx
+++ b/packages/primitives/src/lib/toggle/toggle.tsx
@@ -5,7 +5,7 @@ import {
   useSignal,
 } from '@builder.io/qwik';
 
-export interface ToggleProps {
+export type ToggleProps = {
   disabled?: boolean;
   /**
    * The controlled state of the toggle.
@@ -44,7 +44,6 @@ export const Toggle = component$((props: ToggleProps) => {
         if (!disabled) {
           pressedState.value = !pressedState.value;
           if (onClick$) {
-            // REPORT MISSING QwikMouseEvent to Qwik github
             onClick$(event);
           }
         }


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Change the primitives components to be lite components.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
