### PR TITLE
feat(toast) Use html output element

### DIFF
--- a/packages/primitives/src/lib/toast/toast.tsx
+++ b/packages/primitives/src/lib/toast/toast.tsx
@@ -4,12 +4,18 @@ export type ToastProps = {
    */
   label?: string;
   class?: string;
+  /**
+   * Aria role: default 'status'.
+   * @description The toast uses the html element output, which has implicit role 'status'
+   * For information that requires an immediate attention of the user use 'alert'.
+   */
+  role?: 'alert' | 'status';
 }
 
 export const Toast = ({ label = 'New Message', ...toastProps }: ToastProps) => {
   return (
-    <div {...toastProps}>
+    <output {...toastProps}>
       <span>{label}</span>
-    </div>
+    </output>
   );
 };


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description
As described in #239, using `output` html element improve the a11y to announce a message after a user action or time-sensitive information (which is usually what a Toast is for).
This is a first PR to start playing with the project a little.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality (Not applicable)
