### PR TITLE
fix: changed tooltip behaviour

### DIFF
--- a/packages/headless/src/components/tooltip/tooltip.tsx
+++ b/packages/headless/src/components/tooltip/tooltip.tsx
@@ -54,7 +54,8 @@ export const Tooltip = component$(
     });
 
     const showTooltip = $(() => {
-      stateSignal.value = 'unpositioned';
+      update();
+      setTimeout(() => (stateSignal.value = 'positioned'), durationMs);
     });
 
     const hideTooltip = $(() => {


### PR DESCRIPTION
updated the stateSignal value inside showTooltip function

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

* Changed stateSignal value to positioned in showTooltip method
* Added setTimeout to update the tooltip's value before it is shown.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. The tooltip was only shown for the first time, it has hovered.
- 2. The tooltip must be shown every time it has hovered.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
