### PR TITLE
fix(preview-code-example): Update component tab to support light mode and improve contrast

### DIFF
--- a/apps/website/src/components/preview-code-example/preview-code-example.tsx
+++ b/apps/website/src/components/preview-code-example/preview-code-example.tsx
@@ -12,7 +12,7 @@ export const PreviewCodeExample = component$(() => {
           Code
         </Tab>
       </TabList>
-      <TabPanel class="rounded-b-xl  p-12 bg-slate-700">
+      <TabPanel class="rounded-b-xl  p-12 bg-slate-200 dark:bg-slate-900">
         <section class="flex flex-col items-center">
           <Slot name="actualComponent" />
         </section>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [x] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

1. When users view the PreviewCodeExample component in light mode, they can now clearly distinguish the TabPanels and read the content without any visibility issues.
1. This fix improves the overall accessibility of the component, ensuring that users with different visual needs can easily interact with the content.

# Screenshots/Demo
Before: 
![image](https://github.com/qwikifiers/qwik-ui/assets/42738259/3b1524f3-5463-43d1-8e50-15312605042a)
After: 
![image](https://github.com/qwikifiers/qwik-ui/assets/42738259/fc46e26c-7217-41e6-8969-ab7e2c1104fa)
![image](https://github.com/qwikifiers/qwik-ui/assets/42738259/047d9fec-7ca6-440e-877e-7633de4c4e5e)
* **Note:** The border styling of the accordion items in light mode will be handled in a separate PR to ensure that the changes are implemented independently and do not create any dependencies on this current fix. As such, the current fix focuses solely on resolving the contrast issue in light mode for the PreviewCodeExample component.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

Please review the changes and provide any feedback or suggestions. The focus of this fix is to improve the accessibility of the `PreviewCodeExample` component, ensuring that it meets the necessary standards for a11y.
