### PR TITLE
fix: types path in all packages

### DIFF
--- a/packages/kit-headless/package.json
+++ b/packages/kit-headless/package.json
@@ -8,7 +8,7 @@
   "main": "./index.qwik.cjs",
   "qwik": "./index.qwik.mjs",
   "module": "./index.qwik.mjs",
-  "types": "./packages/kit-headless/src/index.d.ts",
+  "types": "./qwik-ui/packages/kit-headless/src/index.d.ts",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/kit-material/package.json
+++ b/packages/kit-material/package.json
@@ -8,7 +8,7 @@
   "main": "./lib/index.qwik.cjs",
   "qwik": "./lib/index.qwik.mjs",
   "module": "./lib/index.qwik.mjs",
-  "types": "./packages/kit-material/src/index.d.ts",
+  "types": "./qwik-ui/packages/kit-material/src/index.d.ts",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/kit-tailwind/package.json
+++ b/packages/kit-tailwind/package.json
@@ -7,7 +7,7 @@
   },
   "main": "./index.qwik.cjs",
   "qwik": "./index.qwik.mjs",
-  "types": "./packages/kit-tailwind/src/index.d.ts",
+  "types": "./qwik-ui/packages/kit-tailwind/src/index.d.ts",
   "module": "./index.qwik.mjs",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

For some reason, the generated types path was added the "qwik-ui" folder (which wasn't there before)