### PR TITLE
fix(website): fix initial theme usage when os is in dark mode

### DIFF
--- a/apps/website/src/root.tsx
+++ b/apps/website/src/root.tsx
@@ -39,8 +39,14 @@ export default component$(() => {
   useContextProvider(ROOT_STORE_CONTEXT_ID, rootStore);
 
   useVisibleTask$(() => {
-    rootStore.mode =
-      localStorage.getItem(THEME_STORAGE_KEY) === 'dark' ? 'dark' : 'light';
+    const userStoredTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    if (userStoredTheme) {
+      rootStore.mode = userStoredTheme === 'dark' ? 'dark' : 'light';
+    } else {
+      rootStore.mode = window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+    }
   });
 
   // TODO: remove this old state once refactored


### PR DESCRIPTION
Add window.matchMedia as a fallback to determine light/dark theme when there's no localStorage value for theme-settings

# What is it?

- [ ] Feature / enhancement
- [+] Bug
- [ ] Docs / tests

# Description

Tiny change to fix the website header.

# Use cases and why

Described here https://github.com/qwikifiers/qwik-ui/issues/392

# Screenshots/Demo

![image](https://github.com/qwikifiers/qwik-ui/assets/7424209/f240f181-a7c6-4b24-b101-270b94c61c80)

# Checklist:

- [+] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [+] I have performed a self-review of my own code
- [n/a] I have made corresponding changes to the documentation
- [n/a] Added new tests to cover the fix / functionality
