### PR TITLE
feat(headless): separator component

### DIFF
--- a/apps/website/src/_state/component-statuses.ts
+++ b/apps/website/src/_state/component-statuses.ts
@@ -44,6 +44,7 @@ export const statusByComponent: ComponentKitsStatuses = {
     Combobox: ComponentStatus.Draft,
     Popover: ComponentStatus.Draft,
     Select: ComponentStatus.Draft,
+    Separator: ComponentStatus.Beta,
     Tabs: ComponentStatus.Beta,
     Toggle: ComponentStatus.Planned,
     Tooltip: ComponentStatus.Draft

--- a/apps/website/src/routes/docs/_components/status-banner/status-banner.tsx
+++ b/apps/website/src/routes/docs/_components/status-banner/status-banner.tsx
@@ -17,7 +17,7 @@ function getMessageByStatus(status?: ComponentStatus) {
     case ComponentStatus.Ready:
       return (
         <>
-          This component is <strong>Production Readty</strong>
+          This component is <strong>Production Ready</strong>
         </>
       );
     case ComponentStatus.Beta:

--- a/apps/website/src/routes/docs/headless/(components)/separator/examples.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/separator/examples.tsx
@@ -1,0 +1,33 @@
+import { component$, Slot } from '@builder.io/qwik';
+import { Separator } from '@qwik-ui/headless';
+import { PreviewCodeExample } from '../../../_components/preview-code-example/preview-code-example';
+
+export const MainExample = component$(() => {
+  return (
+    <PreviewCodeExample>
+      <div q:slot="actualComponent">
+        <div>
+          <h1 class="text-lg">Qwik UI Headless</h1>
+          <p class="text-sm">Accessible, Unstyled Qwik UI Components</p>
+        </div>
+        <Separator orientation="horizontal" class="h-px my-1 bg-primary" />
+        <menu class="flex gap-2">
+          <li>
+            <a href="/docs/headless/introduction/">Introduction</a>
+          </li>
+          <Separator orientation="vertical" class="w-px mx-1 bg-primary" />
+          <li>
+            <a href="/docs/headless/install/">Installation</a>
+          </li>
+          <Separator orientation="vertical" class="w-px mx-1 bg-primary" />
+          <li>
+            <a href="/docs/headless/contributing/">Contributing</a>
+          </li>
+        </menu>
+      </div>
+      <div q:slot="codeExample">
+        <Slot />
+      </div>
+    </PreviewCodeExample>
+  );
+});

--- a/apps/website/src/routes/docs/headless/(components)/separator/index.mdx
+++ b/apps/website/src/routes/docs/headless/(components)/separator/index.mdx
@@ -1,0 +1,62 @@
+---
+title: Qwik UI | Separator
+---
+import { StatusBanner } from '../../../_components/status-banner/status-banner';
+import {statusByComponent} from '../../../../../_state/component-statuses';
+import { MainExample } from './examples';
+import { APITable } from '../../../_components/api-table/api-table';
+
+<StatusBanner status={statusByComponent.headless.Separator}/>
+
+# Separator
+
+#### A separator separates and distinguishes sections of content or groups of menuitems
+
+<MainExample>
+	```tsx
+	<div>
+		<div>
+			<h1 class="text-lg">Qwik UI Headless</h1>
+			<p class="text-sm">Accessible, Unstyled Qwik UI Components</p>
+		</div>
+		<Separator orientation="horizontal" class="h-px my-1 bg-primary" />
+		<menu class="flex gap-2">
+			<li>
+				<a href="/docs/headless/introduction/">Introduction</a>
+			</li>
+			<Separator orientation="vertical" class="w-px mx-1 bg-primary" />
+			<li>
+				<a href="/docs/headless/install/">Installation</a>
+			</li>
+			<Separator orientation="vertical" class="w-px mx-1 bg-primary" />
+			<li>
+				<a href="/docs/headless/contributing/">Contributing</a>
+			</li>
+		</menu>
+	</div>
+```
+</MainExample>
+
+Qwik UI's Separator implementation follows [WAI-Aria separator role requirements](https://www.w3.org/TR/wai-aria-1.2/#separator). This separator is static and should not be used for interactivity.
+
+##### ✨ Features
+- Supports both horizontal and vertical orientation
+
+## API
+<APITable
+	propDescriptors={[
+		{
+		name: "orientation",
+		type: "enum",
+		info: '"horizontal" | "vertical"',
+		description:
+			"The orientation of the separator. Defaults to horizontal.",
+		},
+		{
+		name: "decorative",
+		type: "boolean",
+		description:
+			"Indicates that the element is purely decorative and should not be included in the accessibility tree.",
+		},
+	]}
+/>

--- a/apps/website/src/routes/docs/headless/(components)/separator/index.mdx
+++ b/apps/website/src/routes/docs/headless/(components)/separator/index.mdx
@@ -42,6 +42,15 @@ Qwik UI's Separator implementation follows [WAI-Aria separator role requirements
 ##### ✨ Features
 - Supports both horizontal and vertical orientation
 
+<div class="mb-6 flex flex-col gap-2">
+  [View Source Code ↗️](https://github.com/qwikifiers/qwik-ui/tree/main/packages/kit-headless/src/components/separator)
+
+[Report an issue 🚨](https://github.com/qwikifiers/qwik-ui/issues)
+
+[Edit This Page 🗒️](<https://github.com/qwikifiers/qwik-ui/edit/main/apps/website/src/routes/docs/headless/(components)/separator/index.mdx>)
+
+</div>
+
 ## API
 <APITable
 	propDescriptors={[

--- a/apps/website/src/routes/docs/headless/menu.md
+++ b/apps/website/src/routes/docs/headless/menu.md
@@ -12,6 +12,7 @@
 - [Combobox](/docs/headless/combobox)
 - [Popover](/docs/headless/popover)
 - [Select](/docs/headless/select)
+- [Separator](/docs/headless/separator)
 - [Tabs](/docs/headless/tabs)
 - [Toggle](/docs/headless/toggle)
 - [Tooltip](/docs/headless/tooltip)

--- a/packages/kit-headless/src/components/separator/separator.spec.tsx
+++ b/packages/kit-headless/src/components/separator/separator.spec.tsx
@@ -1,0 +1,58 @@
+import { Separator } from './separator';
+
+describe('Critical Functionality', () => {
+  it('INIT', () => {
+    cy.mount(<Separator />);
+
+    cy.checkA11yForComponent();
+  });
+
+  it('GIVEN no orientation prop THEN aria-orientation is set unset', () => {
+    cy.mount(<Separator />);
+
+    cy.findByRole('separator').should('not.have.attr', 'aria-orientation');
+  });
+
+  it("GIVEN orientation prop 'horizontal' THEN aria-orientation is unset", () => {
+    cy.mount(<Separator orientation="horizontal" />);
+
+    cy.findByRole('separator').should('not.have.attr', 'aria-orientation');
+  });
+
+  it("GIVEN orientation prop 'vertical' THEN aria-orientation is set to 'vertical'", () => {
+    cy.mount(<Separator orientation="vertical" />);
+
+    cy.findByRole('separator').should('have.attr', 'aria-orientation', 'vertical');
+  });
+
+  it("GIVEN no orientation prop THEN data-orientation is set to 'horizontal'", () => {
+    cy.mount(<Separator />);
+
+    cy.findByRole('separator').should('not.have.attr', 'aria-orientation');
+  });
+
+  it("GIVEN orientation prop 'horizontal' THEN data-orientation is set to 'horizontal'", () => {
+    cy.mount(<Separator orientation="horizontal" />);
+
+    cy.findByRole('separator').should('not.have.attr', 'aria-orientation');
+  });
+
+  it("GIVEN orientation prop 'vertical' THEN data-orientation is set to 'vertical'", () => {
+    cy.mount(<Separator orientation="vertical" />);
+
+    cy.findByRole('separator').should('have.attr', 'aria-orientation', 'vertical');
+  });
+
+  it("GIVEN decorative prop THEN role is set to 'none' AND aria-orientation is unset", () => {
+    cy.mount(<Separator decorative />);
+
+    cy.findByRole('none').should('not.have.attr', 'aria-orientation');
+  });
+
+  it('GIVEN invalid orientation prop THEN console.warn is called', () => {
+    const consoleSpy = cy.spy(console, 'warn');
+    cy.mount(<Separator orientation={'invalid' as any} />);
+
+    cy.wrap(consoleSpy).should('have.been.calledWithMatch', /Invalid prop 'orientation'/);
+  });
+});

--- a/packages/kit-headless/src/components/separator/separator.tsx
+++ b/packages/kit-headless/src/components/separator/separator.tsx
@@ -1,10 +1,13 @@
-import { component$, HTMLAttributes, useComputed$ } from '@builder.io/qwik';
+import { QwikIntrinsicElements } from '@builder.io/qwik';
+import { component$, useComputed$ } from '@builder.io/qwik';
 
 const ORIENTATIONS = ['horizontal', 'vertical'] as const;
 
 type Orientation = (typeof ORIENTATIONS)[number];
 
-export interface SeparatorProps extends HTMLAttributes<HTMLElement> {
+type QwikDiv = QwikIntrinsicElements['div'];
+
+export interface SeparatorProps extends QwikDiv {
   /**
    * Either `vertical` or `horizontal`. Defaults to `horizontal`.
    */
@@ -40,7 +43,7 @@ export const Separator = component$(
 
     // `aria-orientation` defaults to `horizontal` so we only need it if `orientation` is vertical
     const ariaOrientation = useComputed$(() =>
-      orientation.value === 'vertical' ? orientation : undefined
+      orientation.value === 'vertical' ? orientation.value : undefined
     );
 
     const semanticProps = useComputed$(() =>
@@ -48,10 +51,12 @@ export const Separator = component$(
         ? { role: 'none' }
         : {
             role: 'separator',
-            'aria-orientation': ariaOrientation
+            'aria-orientation': ariaOrientation.value
           }
     );
 
-    return <div data-orientation={orientation} {...semanticProps} {...props} />;
+    return (
+      <div data-orientation={orientation.value} {...semanticProps.value} {...props} />
+    );
   }
 );

--- a/packages/kit-headless/src/components/separator/separator.tsx
+++ b/packages/kit-headless/src/components/separator/separator.tsx
@@ -1,0 +1,57 @@
+import { component$, HTMLAttributes, useComputed$ } from '@builder.io/qwik';
+
+const ORIENTATIONS = ['horizontal', 'vertical'] as const;
+
+type Orientation = (typeof ORIENTATIONS)[number];
+
+export interface SeparatorProps extends HTMLAttributes<HTMLElement> {
+  /**
+   * Either `vertical` or `horizontal`. Defaults to `horizontal`.
+   */
+  orientation?: Orientation;
+  /**
+   * If true, accessibility-related attributes
+   * are updated so that that the element is not included in the accessibility tree.
+   */
+  decorative?: boolean;
+}
+
+export const Separator = component$(
+  ({
+    orientation: orientationProp = 'horizontal',
+    decorative,
+    ...props
+  }: SeparatorProps) => {
+    const orientation = useComputed$(() => {
+      if (ORIENTATIONS.includes(orientationProp)) {
+        return orientationProp;
+      }
+
+      console.warn(
+        `Invalid prop 'orientation' of value '${orientationProp}' supplied to 'separator',
+        expected one of:
+        - horizontal
+        - vertical
+
+        Defaulting to 'horizontal'.`
+      );
+      return 'horizontal';
+    });
+
+    // `aria-orientation` defaults to `horizontal` so we only need it if `orientation` is vertical
+    const ariaOrientation = useComputed$(() =>
+      orientation.value === 'vertical' ? orientation : undefined
+    );
+
+    const semanticProps = useComputed$(() =>
+      decorative
+        ? { role: 'none' }
+        : {
+            role: 'separator',
+            'aria-orientation': ariaOrientation
+          }
+    );
+
+    return <div data-orientation={orientation} {...semanticProps} {...props} />;
+  }
+);

--- a/packages/kit-headless/src/index.ts
+++ b/packages/kit-headless/src/index.ts
@@ -21,6 +21,7 @@ export * from './components/tooltip/tooltip';
 export * as Checkbox from './components/checkbox/checkbox';
 export * as CheckboxProps from './components/checkbox/checkbox';
 export * from './components/select';
+export * from './components/separator/separator';
 export * from './components/slider';
 export * from './components/breadcrumb';
 export * from './components/navigation-bar/navigation-bar';


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description
Addition of a headless separator component closes #397. This is my first time contributing to open-source so I decided to start off with a simple yet handy component in the separator. 

The separator component complies to the WAI-Aria separator role. It is currently only static. In the future the separator could updated to be made focusable and used for interactivity. However, I think creating headless window splitter component that follows the [WAI Splitter Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) would make more sense.

The implementation follows very closely to how it is implemented in radix ui for react.  [Radix separator](https://www.radix-ui.com/primitives/docs/components/separator) for reference,

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

 1. Creating a division between items in a menu
     - Visually differentiate between or group together different menu components or buttons and
     - Make the notion of these divisions aria accessible.

 3. Creating a page margin
     - Create a visual guide of a page margin.  
     - Make the location of the page margin aria accessible. 

# Screenshots/Demo

<!-- Add your screenshots here -->
| ![separator component used in a menu structure with basic styling](https://github.com/qwikifiers/qwik-ui/assets/65082676/1908bfb7-fcac-42d9-a165-dee9e4cf42d0) | 
|:--:| 
| *separator component used in a menu structure with basic styling* |

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have made corresponding changes to the documentation
- [x] I have performed a self-review of my own code
- [x] Added new tests to cover the fix / functionality
