### PR TITLE
fix(bump qwik dep version): bump qwik peer dep in packages

### DIFF
--- a/packages/kit-headless/package.json
+++ b/packages/kit-headless/package.json
@@ -22,7 +22,7 @@
   "private": false,
   "scripts": {},
   "peerDependencies": {
-    "@builder.io/qwik": ">1.1.0"
+    "@builder.io/qwik": ">1.2.11"
   },
   "dependencies": {
     "@floating-ui/dom": "1.0.10",

--- a/packages/kit-headless/vite.config.ts
+++ b/packages/kit-headless/vite.config.ts
@@ -17,9 +17,12 @@ export default defineConfig({
       tsconfigPath: join(dirname(fileURLToPath(import.meta.url)), 'tsconfig.lib.json'),
 
       afterDiagnostic(ds) {
+        // ensure DTS errors are still visible - otherwise get swallowed and silent
+        console.log((ds ?? []).map((d) => d.messageText));
+
         const nonPortableTypeErrors = ds.filter((d) => d.code === 2742);
         if (nonPortableTypeErrors.length > 0) {
-          // stop the build - yes with an empty promise - that's what the func expects
+          // stop the build for 2742 specifically
           return Promise.reject(nonPortableTypeErrors);
         }
 

--- a/packages/kit-tailwind/package.json
+++ b/packages/kit-tailwind/package.json
@@ -36,6 +36,6 @@
     "daisyui": "^2.50.1"
   },
   "peerDependencies": {
-    "@builder.io/qwik": ">1.1.0"
+    "@builder.io/qwik": ">1.2.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
   packages/kit-headless:
     dependencies:
       '@builder.io/qwik':
-        specifier: '>1.1.0'
-        version: 1.1.5(undici@5.23.0)
+        specifier: '>1.2.11'
+        version: 1.2.12(undici@5.23.0)
       '@floating-ui/dom':
         specifier: 1.0.10
         version: 1.0.10
@@ -335,8 +335,8 @@ importers:
   packages/kit-tailwind:
     dependencies:
       '@builder.io/qwik':
-        specifier: '>1.1.0'
-        version: 1.1.5(undici@5.23.0)
+        specifier: '>1.2.11'
+        version: 1.2.12(undici@5.23.0)
       daisyui:
         specifier: ^2.50.1
         version: 2.50.1(autoprefixer@10.4.15)(postcss@8.4.29)(ts-node@10.9.1)
@@ -3325,16 +3325,6 @@ packages:
       - supports-color
     dev: true
 
-  /@builder.io/qwik@1.1.5(undici@5.23.0):
-    resolution: {integrity: sha512-/CZzZaUPctUBHNjchJRXV+JC28HZtv4JteCKnpqjp8YcvzHNuB3A0FpIGEzEWD/F/pg+4YunvxrBSb9ZdPJROw==}
-    engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
-    hasBin: true
-    peerDependencies:
-      undici: ^5.14.0
-    dependencies:
-      undici: 5.23.0
-    dev: false
-
   /@builder.io/qwik@1.2.12(undici@5.23.0):
     resolution: {integrity: sha512-17dwM9BR0NJtrWLPlDygdYMlRkBAMEp8nkPIhhApSH5c/ESQMlbVg7Rm665WkBTf87+Epd+b7cC7Ky+8iYGjmA==}
     engines: {node: '>=16.8.0 <18.0.0 || >=18.11'}
@@ -3344,7 +3334,6 @@ packages:
     dependencies:
       csstype: 3.1.2
       undici: 5.23.0
-    dev: true
 
   /@builder.io/qwik@1.2.6(undici@5.23.0):
     resolution: {integrity: sha512-Cm1sLAimML55I5T1RI80R1lLgI4cnSeQt5obQtcMKa8wMmf2/luEyQaEkeN2fV3sp/gaVXCfAuKaddXK6ONdww==}


### PR DESCRIPTION
- since packages were depending on a lower version they still exhibited the TS4023 error
- using the latest qwik version resolves that

fix #396

# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests


# Use cases and why

To successfully generate the missing d.ts files (as per the bug #396)


# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
