### PR TITLE
fix(docs): fluffy button example now has a default export, changed to…

### DIFF
--- a/apps/website/src/routes/docs/fluffy/(components)/button/examples.tsx
+++ b/apps/website/src/routes/docs/fluffy/(components)/button/examples.tsx
@@ -1,6 +1,6 @@
 import { JSXNode, component$ } from '@builder.io/qwik';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import fluffyButtonCode from '../../../../../../../../packages/kit-fluffy/src/components/button/button?raw';
+import Button from '../../../../../../../../packages/kit-fluffy/src/components/button/button?raw';
 import { CodeExampleContainer } from '../../../_components/code-example/code-example-container';
 import { Highlight } from '../../../_components/highlight/highlight';
 import { PreviewCodeExampleVertical } from '../../../_components/preview-code-example/preview-code-example-vertical';
@@ -62,9 +62,7 @@ export const examples: Record<string, Example> = {
   },
 };
 
-export const InstallExample = component$(() => (
-  <CodeExampleContainer code={fluffyButtonCode} />
-));
+export const InstallExample = component$(() => <CodeExampleContainer code={Button} />);
 
 export const ShowExample = component$(({ example }: ShowExampleProps) => {
   const { component, code, cssClasses = '' } = examples[example];

--- a/apps/website/src/routes/docs/fluffy/(components)/navigation-bar/examples.tsx
+++ b/apps/website/src/routes/docs/fluffy/(components)/navigation-bar/examples.tsx
@@ -6,11 +6,11 @@ export default component$(() => {
     <>
       <h2>This is the documentation for the Navigation Bar</h2>
 
-      <div class="flex flex-col gap-8 mt-4">
+      <div class="mt-4 flex flex-col gap-8">
         <h2>Basic Example</h2>
 
         <NavigationBar class="bg-base-100 rounded-lg">
-          <a q:slot="navbar-left" class="btn btn-ghost normal-case text-xl">
+          <a q:slot="navbar-left" class="btn btn-ghost text-xl normal-case">
             tailwindUI
           </a>
           <ul q:slot="navbar-center" class="menu  menu-horizontal px-1">
@@ -30,7 +30,7 @@ export default component$(() => {
                   <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
                 </svg>
               </a>
-              <ul class="p-2 bg-base-100">
+              <ul class="bg-base-100 p-2">
                 <li>
                   <a>Submenu 1</a>
                 </li>
@@ -43,13 +43,13 @@ export default component$(() => {
               <a>Item 3</a>
             </li>
           </ul>
-          <a q:slot="navbar-right" class="btn btn-ghost normal-case text-xl">
+          <a q:slot="navbar-right" class="btn btn-ghost text-xl normal-case">
             tailwindUI
           </a>
         </NavigationBar>
 
         <NavigationBar class="bg-base-100 rounded-lg">
-          <a q:slot="navbar-left" class="btn btn-ghost normal-case text-xl">
+          <a q:slot="navbar-left" class="btn btn-ghost text-xl normal-case">
             tailwindUI
           </a>
           <ul q:slot="navbar-right" class="menu  menu-horizontal px-1">
@@ -69,7 +69,7 @@ export default component$(() => {
                   <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
                 </svg>
               </a>
-              <ul class="p-2 bg-base-100">
+              <ul class="bg-base-100 p-2">
                 <li>
                   <a>Submenu 1</a>
                 </li>
@@ -85,7 +85,7 @@ export default component$(() => {
         </NavigationBar>
         <h2>Custom css</h2>
         <NavigationBar class=" bg-primary rounded-lg">
-          <a q:slot="navbar-left" class="btn btn-ghost normal-case text-xl">
+          <a q:slot="navbar-left" class="btn btn-ghost text-xl normal-case">
             tailwindUI
           </a>
           <ul q:slot="navbar-right" class="menu   menu-horizontal px-1">
@@ -105,7 +105,7 @@ export default component$(() => {
                   <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
                 </svg>
               </a>
-              <ul class="p-2 bg-base-100">
+              <ul class="bg-base-100 p-2">
                 <li>
                   <a>Submenu 1</a>
                 </li>

--- a/apps/website/src/routes/docs/headless/(components)/toggle/examples.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/toggle/examples.tsx
@@ -1,17 +1,27 @@
-import { Slot, component$ } from '@builder.io/qwik';
-import { Toggle } from '@qwik-ui/primitives';
-import { PreviewCodeExampleTabsDeprecated } from '../../../_components/preview-code-example/preview-code-example-tabs';
+import { component$, type JSXNode } from '@builder.io/qwik';
 
-export const Example01 = component$(() => {
+import { PreviewCodeExampleTabs } from '../../../_components/preview-code-example/preview-code-example-tabs';
+// import styles from './index.css?inline';
+
+export type Example = {
+  component: JSXNode;
+  code: string;
+  cssClasses?: string;
+};
+
+export const examples: Record<string, Example> = {};
+
+export type ShowExampleProps = {
+  example: string;
+};
+
+export const ShowExample = component$(({ example }: ShowExampleProps) => {
+  const { component, code, cssClasses = '' } = examples[example];
   return (
-    <PreviewCodeExampleTabsDeprecated>
-      <div q:slot="actualComponent">
-        <Toggle pressed={true} onClick$={() => console.log('Toggle')} />
+    <PreviewCodeExampleTabs code={code}>
+      <div q:slot="actualComponent" class={['tabs-example mr-auto', cssClasses]}>
+        {component}
       </div>
-
-      <div q:slot="codeExample">
-        <Slot />
-      </div>
-    </PreviewCodeExampleTabsDeprecated>
+    </PreviewCodeExampleTabs>
   );
 });

--- a/apps/website/src/routes/docs/headless/(components)/toggle/index.mdx
+++ b/apps/website/src/routes/docs/headless/(components)/toggle/index.mdx
@@ -2,7 +2,6 @@
 title: Qwik UI | Toggle
 ---
 
-import { Example01 } from './examples';
 import { CodeExample } from '../../../_components/code-example/code-example';
 import { KeyboardInteractionTable } from '../../../_components/keyboard-interaction-table/keyboard-interaction-table';
 import { APITable } from '../../../_components/api-table/api-table';

--- a/packages/kit-fluffy/src/components/button/button.tsx
+++ b/packages/kit-fluffy/src/components/button/button.tsx
@@ -112,3 +112,5 @@ export const Button = component$<ButtonProps>(
     );
   },
 );
+
+export default Button;


### PR DESCRIPTION
…ggle to current preview tabs

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
