### PR TITLE
fix(vite.config.ts): remove external rollupOptions

### DIFF
--- a/packages/kit-headless/vite.config.ts
+++ b/packages/kit-headless/vite.config.ts
@@ -57,8 +57,6 @@ export default defineConfig({
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
-      // External packages that should not be bundled into your library.
-      external: ['@floating-ui/dom', 'country-list-json', 'libphonenumber-js'],
       output: {
         preserveModules: true,
         preserveModulesRoot: 'packages/kit-headless/src',


### PR DESCRIPTION
fix #473

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

vite.config.ts had `external: ['@floating-ui/dom', 'country-list-json', 'libphonenumber-js']`.

I think the problem is that if headless kit uses any of these packages for UI behavior, each package has to be added to the @qwik-ui/headless bundle. Otherwise Rollup has no way to resolve the package.

Hence I propose removing all of that `external: ['@floating-ui/dom', 'country-list-json', 'libphonenumber-js']` line for now. I tested this using pnpm link and it seemed to solve #473. Can we try to merge this and see if it works? We can always revert if it doesn't, and try to optimize the final bundles later if it does.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
