### PR TITLE
fix(accordion): disabled in safari

### DIFF
--- a/packages/kit-headless/src/components/accordion/accordion-trigger.tsx
+++ b/packages/kit-headless/src/components/accordion/accordion-trigger.tsx
@@ -121,18 +121,22 @@ export const AccordionTrigger = component$(
         aria-disabled={disabled}
         data-trigger-id={triggerId}
         data-state={isTriggerExpandedSig.value ? 'open' : 'closed'}
-        onClick$={[
-          $(() => {
-            selectedTriggerIdSig.value = triggerId;
+        onClick$={
+          disabled
+            ? []
+            : [
+                $(() => {
+                  selectedTriggerIdSig.value = triggerId;
 
-            setSelectedTriggerIndexSig$();
+                  setSelectedTriggerIndexSig$();
 
-            collapsible
-              ? (isTriggerExpandedSig.value = !isTriggerExpandedSig.value)
-              : (isTriggerExpandedSig.value = true);
-          }),
-          props.onClick$,
-        ]}
+                  collapsible
+                    ? (isTriggerExpandedSig.value = !isTriggerExpandedSig.value)
+                    : (isTriggerExpandedSig.value = true);
+                }),
+                props.onClick$,
+              ]
+        }
         aria-expanded={isTriggerExpandedSig.value}
         aria-controls={contentId}
         onKeyDown$={[


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

In Safari you can click on the +/- icon for accordion and the contents are still shown. this fixes that by avoiding the onclick handlers

