### PR TITLE
fix: pagination

### DIFF
--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/basic.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/basic.tsx
@@ -1,7 +1,9 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
+import styles from '../index.css?inline';
 
 export default component$(() => {
+  useStylesScoped$(styles);
   const selectedPage = useSignal(1);
   const totalPages = useSignal(10);
 
@@ -13,7 +15,12 @@ export default component$(() => {
         onPageChange$={(page) => {
           selectedPage.value = page;
         }}
-        class="flex gap-3"
+        class="pagination-wrapper"
+        selectedClass="pagination-selected-btn"
+        defaultClass="pagination-btn"
+        dividerClass="pagination-divider"
+        prevButtonClass="prevNextButtons"
+        nextButtonClass="prevNextButtons"
       />
     </div>
   );

--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/custom-arrows.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/custom-arrows.tsx
@@ -1,7 +1,9 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
+import styles from '../index.css?inline';
 
 export default component$(() => {
+  useStylesScoped$(styles);
   const selectedPage = useSignal(5);
   const totalPages = useSignal(20);
 
@@ -13,6 +15,12 @@ export default component$(() => {
         onPageChange$={(page) => {
           selectedPage.value = page;
         }}
+        class="pagination-wrapper"
+        selectedClass="pagination-selected-btn"
+        defaultClass="pagination-btn"
+        dividerClass="pagination-divider"
+        prevButtonClass="prevNextButtons"
+        nextButtonClass="prevNextButtons"
       >
         <span q:slot="prefix"> 👈 </span>
         <span q:slot="suffix"> 👉 </span>

--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/custom-button-labels.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/custom-button-labels.tsx
@@ -1,7 +1,9 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
+import styles from '../index.css?inline';
 
 export default component$(() => {
+  useStylesScoped$(styles);
   const selectedPage = useSignal(1);
   const totalPages = useSignal(10);
 
@@ -14,6 +16,12 @@ export default component$(() => {
           selectedPage.value = page;
         }}
         customArrowTexts={{ previous: 'LEFT', next: 'RIGHT' }}
+        class="pagination-wrapper"
+        selectedClass="pagination-selected-btn"
+        defaultClass="pagination-btn"
+        dividerClass="pagination-divider"
+        prevButtonClass="prevNextButtons"
+        nextButtonClass="prevNextButtons"
       />
     </div>
   );

--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/disabled.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/disabled.tsx
@@ -1,7 +1,9 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
+import styles from '../index.css?inline';
 
 export default component$(() => {
+  useStylesScoped$(styles);
   const selectedPage = useSignal(1);
   const totalPages = useSignal(10);
 
@@ -14,6 +16,12 @@ export default component$(() => {
         onPageChange$={(page) => {
           selectedPage.value = page;
         }}
+        class="pagination-wrapper"
+        selectedClass="pagination-selected-btn"
+        defaultClass="pagination-btn"
+        dividerClass="pagination-divider"
+        prevButtonClass="prevNextButtons"
+        nextButtonClass="prevNextButtons"
       />
     </div>
   );

--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/hide-prev-next-buttons.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/hide-prev-next-buttons.tsx
@@ -1,7 +1,9 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
+import styles from '../index.css?inline';
 
 export default component$(() => {
+  useStylesScoped$(styles);
   const selectedPage = useSignal(1);
   const totalPages = useSignal(10);
 
@@ -15,6 +17,12 @@ export default component$(() => {
         }}
         hidePrevButton={true}
         hideNextButton={true}
+        class="pagination-wrapper"
+        selectedClass="pagination-selected-btn"
+        defaultClass="pagination-btn"
+        dividerClass="pagination-divider"
+        prevButtonClass="prevNextButtons"
+        nextButtonClass="prevNextButtons"
       />
     </div>
   );

--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/interactive.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/interactive.tsx
@@ -1,9 +1,12 @@
-import { component$, useSignal, Slot } from '@builder.io/qwik';
+import { component$, useSignal, Slot, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
 import { Toggle } from '@qwik-ui/tailwind';
+import styles from '../index.css?inline';
 
 export default component$(() => {
-  const selectedPage = useSignal(5);
+  useStylesScoped$(styles);
+
+  const selectedPage = useSignal(1);
   const totalPages = useSignal(20);
 
   const hideNextButton = useSignal(false);
@@ -21,10 +24,14 @@ export default component$(() => {
         onPageChange$={(page) => {
           selectedPage.value = page;
         }}
-        selectedClass="text-sky-500 font-bold px-3"
         hidePrevButton={hidePrevButton.value}
         hideNextButton={hideNextButton.value}
-        gap={'10px'}
+        class="pagination-wrapper"
+        selectedClass="pagination-selected-btn"
+        defaultClass="pagination-btn"
+        dividerClass="pagination-divider"
+        prevButtonClass="prevNextButtons"
+        nextButtonClass="prevNextButtons"
       />
 
       <hr />

--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/interactive.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/interactive.tsx
@@ -12,7 +12,6 @@ export default component$(() => {
   const hideNextButton = useSignal(false);
   const hidePrevButton = useSignal(false);
   const siblingCount = useSignal(1);
-  const boundaryCount = useSignal(1);
 
   return (
     <div class="mt-4 flex flex-col gap-6">
@@ -20,7 +19,6 @@ export default component$(() => {
         selectedPage={selectedPage.value}
         totalPages={totalPages.value}
         siblingCount={siblingCount.value}
-        boundaryCount={boundaryCount.value}
         onPageChange$={(page) => {
           selectedPage.value = page;
         }}
@@ -70,22 +68,6 @@ export default component$(() => {
             value={siblingCount.value}
             onChange$={(e) => {
               siblingCount.value = Number(e.target.value);
-            }}
-          />
-        </label>
-
-        <label class="flex items-center justify-between gap-10">
-          boundaryCount
-          <input
-            type="number"
-            style={{
-              width: '50px',
-              background: 'transparent',
-              textAlign: 'right',
-            }}
-            value={boundaryCount.value}
-            onChange$={(e) => {
-              boundaryCount.value = Number(e.target.value);
             }}
           />
         </label>

--- a/apps/website/src/routes/docs/headless/(components)/pagination/examples/styling.tsx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/examples/styling.tsx
@@ -1,7 +1,9 @@
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
+import styles from '../index.css?inline';
 
 export default component$(() => {
+  useStylesScoped$(styles);
   const selectedPage = useSignal(1);
   const totalPages = useSignal(10);
 

--- a/apps/website/src/routes/docs/headless/(components)/pagination/index.css
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/index.css
@@ -1,0 +1,18 @@
+.pagination-wrapper {
+  @apply flex gap-3;
+}
+.pagination-btn {
+  @apply h-8 !cursor-pointer rounded-md bg-white px-3 text-center text-black hover:bg-slate-200;
+}
+
+.pagination-selected-btn {
+  @apply pointer-events-none h-8  rounded-md bg-slate-500 text-black;
+}
+
+.pagination-divider {
+  @apply h-8 w-8 rounded-md text-white;
+}
+
+.prevNextButtons {
+  @apply h-8 !cursor-pointer rounded-md bg-white px-2 text-black hover:bg-slate-200 disabled:pointer-events-none disabled:opacity-30;
+}

--- a/apps/website/src/routes/docs/headless/(components)/pagination/index.mdx
+++ b/apps/website/src/routes/docs/headless/(components)/pagination/index.mdx
@@ -64,11 +64,13 @@ Here are the notable properties for this component:
       type: 'number',
       description: `set sibling items close to the selected value`,
     },
-    {
+   /*
+   {
       name: 'boundaryCount',
       type: 'number',
       description: `set adjacent items to the start and end page number`,
     },
+    */
     {
       name: 'hidePrevButton',
       type: 'boolean',
@@ -113,7 +115,17 @@ Here are the notable properties for this component:
       name: 'dividerClass',
       type: 'string',
       description: `custom class for the divider item`,
-    }
+    },
+    {
+      name: 'prevButtonClass',
+      type: 'string',
+      description: `custom class for the Next button`,
+    },
+    {
+      name: 'nextButtonClass',
+      type: 'string',
+      description: `custom class for the Next button`,
+    },
   ]}
 />
 

--- a/packages/kit-headless/src/components/pagination/pagination.spec.tsx
+++ b/packages/kit-headless/src/components/pagination/pagination.spec.tsx
@@ -1,0 +1,170 @@
+import { Pagination } from '@qwik-ui/headless';
+import { component$, useSignal } from '@builder.io/qwik';
+
+/**
+ * SUT - System under test
+ * Reference: https://en.wikipedia.org/wiki/System_under_test
+ */
+const Sut = component$(() => {
+  const selectedPage = useSignal(1);
+  const totalPages = useSignal(10);
+
+  return (
+    <>
+      hello pagination
+      <Pagination
+        selectedPage={selectedPage.value}
+        totalPages={totalPages.value}
+        onPageChange$={(page) => {
+          selectedPage.value = page;
+        }}
+        class="flex gap-3"
+      />
+    </>
+  );
+});
+
+describe('Pagination', () => {
+  it(`Given a Pagination
+      WHEN opening it
+      THEN it passes a11y-Tests`, () => {
+    cy.mount(<Sut />);
+
+    cy.checkA11yForComponent();
+  });
+
+  it(`Given a Pagination
+      WHEN opening it 
+      THEN it displays the correct amount of items
+    `, () => {
+    cy.mount(<Sut />);
+    testItems(['1', '2', '3', '4', '...', '10']);
+  });
+
+  it(`Given a Pagination
+      WHEN opening it 
+      AND clicking each item
+      THEN it does display the correct amount of items
+      AND the selected item is disabled
+    `, () => {
+    cy.mount(<Sut />);
+
+    const tests: [number, (number | string)[]][] = [
+      // avoid the first element because already selected
+      // [1, [1, 2, 3, 4, '...', 10]],
+      [2, [1, 2, 3, 4, '...', 10]],
+      [3, [1, 2, 3, 4, '...', 10]],
+      [4, [1, '...', 3, 4, 5, '...', 10]],
+      [5, [1, '...', 4, 5, 6, '...', 10]],
+      [6, [1, '...', 5, 6, 7, '...', 10]],
+      [7, [1, '...', 6, 7, 8, '...', 10]],
+      [8, [1, '...', 7, 8, 9, 10]],
+      [9, [1, '...', 7, 8, 9, 10]],
+      [10, [1, '...', 7, 8, 9, 10]],
+    ];
+
+    tests.forEach(([selectedPage, expectedResult]) => {
+      // click and item to change page
+      cy.contains(selectedPage).click();
+
+      // element is disabled
+      cy.contains(selectedPage).should('be.disabled');
+
+      // pagination contains the expected items
+      testItems(expectedResult);
+    });
+  });
+
+  it(`Given a Pagination
+      WHEN opening it 
+      AND first button is selected
+      THEN the "previous" button is disabled
+    `, () => {
+    cy.mount(<Sut />);
+
+    cy.get('[data-testid="pagination"]').contains('PREV').should('be.disabled');
+  });
+
+  it(`Given a Pagination
+      WHEN opening it 
+      AND last button is selected
+      THEN the "next" button is disabled
+    `, () => {
+    cy.mount(<Sut />);
+    cy.contains('10').click();
+    cy.get('[data-testid="pagination"]').contains('NEXT').should('be.disabled');
+  });
+
+  it(`Given a Pagination
+      WHEN it's disabled
+      THEN all buttons are disabled
+    `, () => {
+    cy.mount(<Pagination selectedPage={5} totalPages={10} disabled />);
+
+    cy.get('[data-testid="pagination"]')
+      .find('button')
+      .each(($el) => {
+        cy.wrap($el).should('be.disabled');
+      });
+  });
+
+  it(`Given a Pagination
+      WHEN the 'customArrowTexts' is set
+      THEN it should display the custom labels
+    `, () => {
+    cy.mount(
+      <Pagination
+        selectedPage={5}
+        totalPages={10}
+        customArrowTexts={{
+          previous: 'LEFT',
+          next: 'RIGHT',
+        }}
+      />,
+    );
+
+    cy.contains('LEFT').should('be.visible');
+    cy.contains('RIGHT').should('be.visible');
+  });
+
+  it(`Given a Pagination
+      WHEN 'hidePrevButton' and 'hideNextButton' are set   
+      THEN 'prev' and 'next' buttons are not visible
+    `, () => {
+    cy.mount(
+      <Pagination selectedPage={4} totalPages={10} hidePrevButton hideNextButton />,
+    );
+
+    cy.contains('LEFT').should('not.exist');
+    cy.contains('RIGHT').should('not.exist');
+  });
+
+  it(`Given a Pagination
+      WHEN 'prefix' and 'suffix' elements are passed as children  
+      THEN they should be visible close to the labels
+    `, () => {
+    cy.mount(
+      <Pagination selectedPage={4} totalPages={10}>
+        <span q:slot="prefix"> 👈 </span>
+        <span q:slot="suffix"> 👉 </span>
+      </Pagination>,
+    );
+
+    cy.contains('PREV').children().first().contains('👈').should('be.visible');
+
+    cy.contains('NEXT').children().last().contains('👉').should('be.visible');
+  });
+});
+
+/*
+ * Helper to check if items are visible in the paginator
+ *
+ * expectedItems  the pagination item that should be visible, i.e. [1, 2, 3, '...', 10]
+ */
+function testItems(expectedItems: (string | number)[]) {
+  cy.get('[data-testid="pagination"]').within(() => {
+    expectedItems.forEach((item) => {
+      cy.contains(item).should('be.visible');
+    });
+  });
+}

--- a/packages/kit-headless/src/components/pagination/pagination.spec.tsx
+++ b/packages/kit-headless/src/components/pagination/pagination.spec.tsx
@@ -1,4 +1,4 @@
-import { Pagination } from '@qwik-ui/headless';
+import { Pagination } from './pagination';
 import { component$, useSignal } from '@builder.io/qwik';
 
 /**

--- a/packages/kit-headless/src/components/pagination/pagination.tsx
+++ b/packages/kit-headless/src/components/pagination/pagination.tsx
@@ -8,7 +8,6 @@ export const Pagination = component$<PaginationProps>((props) => {
     totalPages,
     onPageChange$,
     siblingCount,
-    boundaryCount, // still not supported
     hidePrevButton = false,
     hideNextButton = false,
     disabled = false,
@@ -27,12 +26,7 @@ export const Pagination = component$<PaginationProps>((props) => {
   const isPrevButtonEnabled = () => !hidePrevButton && selectedPage > 1;
   const isNextButtonEnabled = () => !hideNextButton && selectedPage !== totalPages;
 
-  const visibleItems = usePagination(
-    totalPages,
-    selectedPage,
-    siblingCount || 1,
-    boundaryCount || 1, // still not supported
-  );
+  const visibleItems = usePagination(totalPages, selectedPage, siblingCount || 1);
 
   console.log(visibleItems);
   return (

--- a/packages/kit-headless/src/components/pagination/pagination.tsx
+++ b/packages/kit-headless/src/components/pagination/pagination.tsx
@@ -8,7 +8,7 @@ export const Pagination = component$<PaginationProps>((props) => {
     totalPages,
     onPageChange$,
     siblingCount,
-    boundaryCount,
+    boundaryCount, // still not supported
     hidePrevButton = false,
     hideNextButton = false,
     disabled = false,
@@ -31,9 +31,10 @@ export const Pagination = component$<PaginationProps>((props) => {
     totalPages,
     selectedPage,
     siblingCount || 1,
-    boundaryCount || 1,
+    boundaryCount || 1, // still not supported
   );
 
+  console.log(visibleItems);
   return (
     <nav aria-label="pagination" data-testid="pagination" {...rest}>
       <button

--- a/packages/kit-headless/src/components/pagination/pagination.tsx
+++ b/packages/kit-headless/src/components/pagination/pagination.tsx
@@ -16,14 +16,16 @@ export const Pagination = component$<PaginationProps>((props) => {
       previous: previousButtonLabel = 'PREV',
       next: nextButtonLabel = 'NEXT',
     } = {},
-    defaultClass,
-    selectedClass,
-    dividerClass,
+    defaultClass = '',
+    selectedClass = '',
+    dividerClass = '',
+    nextButtonClass = '',
+    prevButtonClass = '',
     ...rest
   } = props;
 
-  const isPrevButtonVisible = () => !hidePrevButton && selectedPage > 1;
-  const isNextButtonVisible = () => !hideNextButton && selectedPage !== totalPages;
+  const isPrevButtonEnabled = () => !hidePrevButton && selectedPage > 1;
+  const isNextButtonEnabled = () => !hideNextButton && selectedPage !== totalPages;
 
   const visibleItems = usePagination(
     totalPages,
@@ -34,33 +36,35 @@ export const Pagination = component$<PaginationProps>((props) => {
 
   return (
     <nav aria-label="pagination" data-testid="pagination" {...rest}>
-      {isPrevButtonVisible() && (
-        <button
-          aria-label={'prevAriaLabel'}
-          disabled={disabled}
-          onClick$={() => {
-            if (selectedPage > 1) {
-              onPageChange$(selectedPage - 1);
-            }
-          }}
-        >
-          <Slot name="prefix" />
-          <span>{previousButtonLabel}</span>
-        </button>
-      )}
+      <button
+        class={nextButtonClass}
+        aria-label={'prevAriaLabel'}
+        disabled={disabled || !isPrevButtonEnabled()}
+        onClick$={() => {
+          if (selectedPage > 1) {
+            onPageChange$(selectedPage - 1);
+          }
+        }}
+      >
+        <Slot name="prefix" />
+        <span>{previousButtonLabel}</span>
+      </button>
 
       {/* Button List */}
       {visibleItems.map((item: string | number, index: number) => {
+        const isSelected = selectedPage === item;
         return (
           <span key={index}>
             {typeof item === 'string' ? (
-              <button class={dividerClass}>...</button>
+              <button class={dividerClass} disabled={true}>
+                ...
+              </button>
             ) : (
               <button
-                class={[selectedPage === item ? selectedClass : defaultClass]}
+                class={[defaultClass, selectedPage === item && selectedClass]}
                 aria-label={`Page ${item} of ${totalPages}`}
                 aria-current={selectedPage === item}
-                disabled={true}
+                disabled={disabled || isSelected}
                 onClick$={() => {
                   onPageChange$(item);
                 }}
@@ -73,20 +77,19 @@ export const Pagination = component$<PaginationProps>((props) => {
       })}
 
       {/* Next Button */}
-      {isNextButtonVisible() && (
-        <button
-          aria-label={'nextAriaLabel'}
-          disabled={disabled}
-          onClick$={() => {
-            if (selectedPage < totalPages) {
-              onPageChange$(selectedPage + 1);
-            }
-          }}
-        >
-          <span>{nextButtonLabel}</span>
-          <Slot name="suffix" />
-        </button>
-      )}
+      <button
+        class={prevButtonClass}
+        aria-label={'nextAriaLabel'}
+        disabled={disabled || !isNextButtonEnabled()}
+        onClick$={() => {
+          if (selectedPage < totalPages) {
+            onPageChange$(selectedPage + 1);
+          }
+        }}
+      >
+        <span>{nextButtonLabel}</span>
+        <Slot name="suffix" />
+      </button>
     </nav>
   );
 });

--- a/packages/kit-headless/src/components/pagination/types/pagination-api.ts
+++ b/packages/kit-headless/src/components/pagination/types/pagination-api.ts
@@ -17,6 +17,7 @@ export type PaginationStyling = {
 
 export type PaginationConfig = {
   siblingCount?: number;
+  // still not supported
   boundaryCount?: number;
   hidePrevButton?: boolean;
   hideNextButton?: boolean;

--- a/packages/kit-headless/src/components/pagination/types/pagination-api.ts
+++ b/packages/kit-headless/src/components/pagination/types/pagination-api.ts
@@ -11,6 +11,8 @@ export type PaginationStyling = {
   defaultClass?: string;
   selectedClass?: string;
   dividerClass?: string;
+  nextButtonClass?: string;
+  prevButtonClass?: string;
 };
 
 export type PaginationConfig = {

--- a/packages/kit-headless/src/components/pagination/use-pagination.spec.ts
+++ b/packages/kit-headless/src/components/pagination/use-pagination.spec.ts
@@ -1,4 +1,4 @@
-import { usePagination } from '@/packages/kit-headless/src/components/pagination/use-pagination';
+import { usePagination } from './use-pagination';
 
 it(`Given totalPages = 1
     AND siblingCount = 1
@@ -19,6 +19,7 @@ it(`Given totalPages = 1
   ];
 
   tests.forEach(([selectedPage, expectedResult]) => {
+    // eslint-disable-next-line qwik/use-method-usage
     testItems(usePagination(10, selectedPage, 1, 1), expectedResult);
   });
 });
@@ -42,6 +43,7 @@ it(`Given totalPages = 1
   ];
 
   tests.forEach(([selectedPage, expectedResult]) => {
+    // eslint-disable-next-line qwik/use-method-usage
     testItems(usePagination(10, selectedPage, 2, 1), expectedResult);
   });
 });

--- a/packages/kit-headless/src/components/pagination/use-pagination.spec.ts
+++ b/packages/kit-headless/src/components/pagination/use-pagination.spec.ts
@@ -1,0 +1,60 @@
+import { usePagination } from '@/packages/kit-headless/src/components/pagination/use-pagination';
+
+it(`Given totalPages = 1
+    AND siblingCount = 1
+    AND different 'selectedPage'
+    THEN it does display the correct amount of items
+  `, () => {
+  const tests: [number, (number | string)[]][] = [
+    [1, [1, 2, 3, 4, '...', 10]],
+    [2, [1, 2, 3, 4, '...', 10]],
+    [3, [1, 2, 3, 4, '...', 10]],
+    [4, [1, '...', 3, 4, 5, '...', 10]],
+    [5, [1, '...', 4, 5, 6, '...', 10]],
+    [6, [1, '...', 5, 6, 7, '...', 10]],
+    [7, [1, '...', 6, 7, 8, '...', 10]],
+    [8, [1, '...', 7, 8, 9, 10]],
+    [9, [1, '...', 7, 8, 9, 10]],
+    [10, [1, '...', 7, 8, 9, 10]],
+  ];
+
+  tests.forEach(([selectedPage, expectedResult]) => {
+    testItems(usePagination(10, selectedPage, 1, 1), expectedResult);
+  });
+});
+
+it(`Given totalPages = 1
+    AND siblingCount = 2
+    AND different 'selectedPage'
+    THEN it does display the correct amount of items
+  `, () => {
+  const tests: [number, (number | string)[]][] = [
+    [1, [1, 2, 3, 4, 5, '...', 10]],
+    [2, [1, 2, 3, 4, 5, '...', 10]],
+    [3, [1, 2, 3, 4, 5, '...', 10]],
+    [4, [1, 2, 3, 4, 5, '...', 10]],
+    [5, [1, '...', 3, 4, 5, 6, 7, '...', 10]],
+    [6, [1, '...', 4, 5, 6, 7, 8, '...', 10]],
+    [7, [1, '...', 6, 7, 8, 9, 10]],
+    [8, [1, '...', 6, 7, 8, 9, 10]],
+    [9, [1, '...', 6, 7, 8, 9, 10]],
+    [10, [1, '...', 6, 7, 8, 9, 10]],
+  ];
+
+  tests.forEach(([selectedPage, expectedResult]) => {
+    testItems(usePagination(10, selectedPage, 2, 1), expectedResult);
+  });
+});
+
+/**
+ * Helper to check if the generated items are exactly what is expected
+ * @param generatedResult
+ * @param expectedResult
+ */
+function testItems(
+  generatedResult: (string | number)[],
+  expectedResult: (string | number)[],
+) {
+  expect(generatedResult).to.have.length(expectedResult.length);
+  expect(generatedResult).to.eql(expectedResult);
+}

--- a/packages/kit-headless/src/components/pagination/use-pagination.ts
+++ b/packages/kit-headless/src/components/pagination/use-pagination.ts
@@ -1,4 +1,91 @@
+interface PageItem {
+  type: 'page' | 'ellipsis';
+  value?: number;
+  key: string;
+}
+
+interface GetPageItemsArgs {
+  page: number;
+  totalPages: number;
+  siblingCount?: number;
+}
+
 export function usePagination(
+  totalPages: number,
+  selectedPage: number,
+  siblingCount = 1,
+  // Still not supported
+  boundaryCount = 1,
+): (number | string)[] {
+  const page = Math.min(Math.max(1, selectedPage), totalPages);
+
+  const getPageItems = ({
+    page,
+    totalPages,
+    siblingCount = 1,
+  }: GetPageItemsArgs): PageItem[] => {
+    const pageItems: PageItem[] = [];
+    const pagesToShow = new Set([1, totalPages]);
+    const firstItemWithSiblings = 3 + siblingCount;
+    const lastItemWithSiblings = totalPages - 2 - siblingCount;
+
+    if (firstItemWithSiblings > lastItemWithSiblings) {
+      for (let p = 2; p <= totalPages - 1; p++) {
+        pagesToShow.add(p);
+      }
+    } else if (page < firstItemWithSiblings) {
+      for (let p = 2; p <= Math.min(firstItemWithSiblings, totalPages); p++) {
+        pagesToShow.add(p);
+      }
+    } else if (page > lastItemWithSiblings) {
+      for (let p = totalPages - 1; p >= Math.max(lastItemWithSiblings, 2); p--) {
+        pagesToShow.add(p);
+      }
+    } else {
+      for (
+        let p = Math.max(page - siblingCount, 2);
+        p <= Math.min(page + siblingCount, totalPages);
+        p++
+      ) {
+        pagesToShow.add(p);
+      }
+    }
+
+    const addPage = (value: number) => {
+      pageItems.push({ type: 'page', value, key: `page-${value}` });
+    };
+    const addEllipsis = () => {
+      pageItems.push({ type: 'ellipsis', key: `ellipsis-${pageItems.length}` });
+    };
+
+    let lastNumber = 0;
+    for (const page of Array.from(pagesToShow).sort((a, b) => a - b)) {
+      if (page - lastNumber > 1) {
+        addEllipsis();
+      }
+      addPage(page);
+      lastNumber = page;
+    }
+
+    return pageItems;
+  };
+
+  const pageItems = getPageItems({ page, totalPages, siblingCount });
+
+  // Convert PageItems to the desired output format
+  const paginationArray: (number | string)[] = [];
+  for (const item of pageItems) {
+    if (item.type === 'page') {
+      paginationArray.push(item.value!); // 'value' is guaranteed to be defined for 'page' type
+    } else {
+      paginationArray.push('...');
+    }
+  }
+
+  return paginationArray;
+}
+
+export function usePagination2(
   totalPages: number,
   selectedPage: number,
   siblingCount = 1,
@@ -40,16 +127,3 @@ export function usePagination(
 
   return paginationArray;
 }
-
-/*
-useTask$(({ track }) => {
-  track(() => [selectedPage, totalPages, siblingCount, boundaryCount]);
-
-  visibleItems.value = generatePaginationArray(
-    totalPages,
-    selectedPage,
-    siblingCount,
-    boundaryCount,
-  );
-});
-*/

--- a/packages/kit-headless/src/components/pagination/use-pagination.ts
+++ b/packages/kit-headless/src/components/pagination/use-pagination.ts
@@ -14,8 +14,6 @@ export function usePagination(
   totalPages: number,
   selectedPage: number,
   siblingCount = 1,
-  // Still not supported
-  boundaryCount = 1,
 ): (number | string)[] {
   const page = Math.min(Math.max(1, selectedPage), totalPages);
 


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests

# Description

1. BEHAVIORS
I have fixed how items are generated the pagination item.
The new algorithm does not support `boundaryCount` anymore but it should mimic the [melt-ui pagination component](https://www.melt-ui.com/docs/builders/pagination).  

A preview:

https://github.com/qwikifiers/qwik-ui/assets/1772083/98e871c0-75cc-47ee-84a0-df2db40a0dd6

2. DOCUMENTATION
I have added styles to the documentation. 
This doc is still not completed but it should be more consistent and prettier than previous version

3. FIXED
I have fixed some behaviors:
- NEXT and PREV buttons are not hidden anymore but just disabled
- Added new properties to customize the look & feel of NEXT / PREV  buttons
- Some minor fixes