### PR TITLE
docs(readme): dynamic all-contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <img src='https://img.shields.io/badge/License-MIT-green.svg' alt='MIT'>
   </a>
   <a href='#contributors'>
-  <img src='https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square' alt='All Contributors'>
+  <img src='https://img.shields.io/github/all-contributors/qwikifiers/qwik-ui?style=flat-square&color=orange' alt='All Contributors'>
   </a>
 
 </div>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Hello, first PR here 👋
I noticed that the all-contributors badge at the top of the README is static (and quite behind the actual count).
Fortunately badges.io right now provides an [endpoint](https://shields.io/badges/git-hub-contributors-from-allcontributors-org) just for this 😃
I've changed the endpoint but kept the same style.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
