### PR TITLE
refactor(modal/examples): replaces fieldsets in example code

### DIFF
--- a/apps/website/src/routes/docs/headless/modal/examples/animation.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/animation.tsx
@@ -32,7 +32,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -40,8 +40,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -49,7 +49,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/auto-focus.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/auto-focus.tsx
@@ -23,7 +23,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -31,8 +31,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               autoFocus
@@ -41,7 +41,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/backdrop-close.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/backdrop-close.tsx
@@ -24,7 +24,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -32,8 +32,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -41,7 +41,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/backdrop.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/backdrop.tsx
@@ -30,7 +30,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -38,8 +38,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -47,7 +47,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/bottom-sheet.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/bottom-sheet.tsx
@@ -12,23 +12,23 @@ export default component$(() => {
     .bottom-sheet::backdrop {
       background: hsla(0, 0%, 0%, 0.5);
     }
-    
+
     .bottom-sheet.modal-showing {
       animation: bottomSheetOpen 0.75s forwards cubic-bezier(0.6, 0.6, 0, 1);
     }
-    
+
     .bottom-sheet.modal-showing::backdrop {
       animation: sheetFadeIn 0.75s forwards cubic-bezier(0.6, 0.6, 0, 1);
     }
-    
+
     .bottom-sheet.modal-closing {
       animation: bottomSheetClose 0.35s forwards cubic-bezier(0.6, 0.6, 0, 1);
     }
-    
+
     .bottom-sheet.modal-closing::backdrop {
       animation: sheetFadeOut 0.35s forwards cubic-bezier(0.6, 0.6, 0, 1);
     }
-    
+
     @keyframes bottomSheetOpen {
       from {
         opacity: 0;
@@ -39,7 +39,7 @@ export default component$(() => {
         transform: translateY(0%);
       }
     }
-    
+
     @keyframes bottomSheetClose {
       from {
         opacity: 1;
@@ -50,7 +50,7 @@ export default component$(() => {
         transform: translateY(100%);
       }
     }
-    
+
     @keyframes sheetFadeIn {
       from {
         opacity: 0;
@@ -59,7 +59,7 @@ export default component$(() => {
         opacity: 1;
       }
     }
-    
+
     @keyframes sheetFadeOut {
       from {
         opacity: 1;
@@ -68,7 +68,7 @@ export default component$(() => {
         opacity: 0;
       }
     }
-    
+
     `);
 
   return (
@@ -92,7 +92,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -100,8 +100,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -109,7 +109,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/inspect.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/inspect.tsx
@@ -23,7 +23,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -31,8 +31,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -40,7 +40,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/main.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/main.tsx
@@ -24,7 +24,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -32,8 +32,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -41,7 +41,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/sheet.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/sheet.tsx
@@ -12,23 +12,23 @@ export default component$(() => {
   .sheet::backdrop {
     background: hsla(0, 0%, 0%, 0.5);
   }
-  
+
   .sheet.modal-showing {
     animation: sheetOpen 0.75s forwards cubic-bezier(0.6, 0.6, 0, 1);
   }
-  
+
   .sheet.modal-showing::backdrop {
     animation: sheetFadeIn 0.75s forwards cubic-bezier(0.6, 0.6, 0, 1);
   }
-  
+
   .sheet.modal-closing {
     animation: sheetClose 0.35s forwards cubic-bezier(0.6, 0.6, 0, 1);
   }
-  
+
   .sheet.modal-closing::backdrop {
     animation: sheetFadeOut 0.35s forwards cubic-bezier(0.6, 0.6, 0, 1);
   }
-  
+
   @keyframes sheetOpen {
     from {
       opacity: 0;
@@ -39,7 +39,7 @@ export default component$(() => {
       transform: translateX(0%);
     }
   }
-  
+
   @keyframes sheetClose {
     from {
       opacity: 1;
@@ -50,7 +50,7 @@ export default component$(() => {
       transform: translateX(100%);
     }
   }
-  
+
   @keyframes sheetFadeIn {
     from {
       opacity: 0;
@@ -59,7 +59,7 @@ export default component$(() => {
       opacity: 1;
     }
   }
-  
+
   @keyframes sheetFadeOut {
     from {
       opacity: 1;
@@ -68,7 +68,7 @@ export default component$(() => {
       opacity: 0;
     }
   }
-  
+
   `);
 
   return (
@@ -92,7 +92,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -100,8 +100,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -109,7 +109,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button

--- a/apps/website/src/routes/docs/headless/modal/examples/transition.tsx
+++ b/apps/website/src/routes/docs/headless/modal/examples/transition.tsx
@@ -22,7 +22,7 @@ export default component$(() => {
     .my-transition.modal-showing, .my-transition.modal-showing::backdrop {
         opacity: 1;
     }
-    
+
     .my-transition.modal-closing, .my-transition.modal-closing::backdrop {
         opacity: 0;
     }
@@ -49,7 +49,7 @@ export default component$(() => {
           <p class="mb-4 leading-5">
             You can update your profile here. Hit the save button when finished.
           </p>
-          <fieldset class="mb-1 flex items-baseline justify-between">
+          <div class="mb-1 flex items-baseline justify-between">
             <label for="name">Name</label>
             <input
               class="mt-2 rounded-sm px-4 py-[10px] text-white"
@@ -57,8 +57,8 @@ export default component$(() => {
               type="text"
               placeholder="John Doe"
             />
-          </fieldset>
-          <fieldset class="flex items-baseline justify-between">
+          </div>
+          <div class="flex items-baseline justify-between">
             <label for="email">Email</label>
             <input
               class="mt-2 rounded-sm px-4 py-3 text-white"
@@ -66,7 +66,7 @@ export default component$(() => {
               type="text"
               placeholder="johndoe@gmail.com"
             />
-          </fieldset>
+          </div>
         </ModalContent>
         <ModalFooter class="flex justify-end gap-4">
           <button


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Better semantic HTML.

# Use cases and why

This commit makes the code closer to the W3C's recommendation, which are quoted below, in two important ways:

- 1. Removes `fieldsets` that had no legends
> The first element inside the fieldset must be a legend element, which provides a label or description for the group

[source](https://www.w3.org/WAI/WCAG21/Techniques/html/H71)

- 2. Applies the recommended pattern for *self-explanatory* forms like the ones used in the examples by replacing the `fieldsets` with `divs`, relying solely on the labels for meaning
> when [...] the individual label associated with each particular control provides a sufficient description [...] the use of the fieldset and legend elements is not required

[source](https://www.w3.org/WAI/WCAG21/Techniques/html/H71)

Alternately, we could add  `legend` tags to each `fieldset` instead of removing them, but the W3C seems to be okay with just having labels. This PR's solution gives the user less text to process while still following W3C principles.  

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
