### PR TITLE
chore(website eslint rules): add "@typescript-eslint/no-explicit-any": "warn"

### DIFF
--- a/apps/website/.eslintrc.json
+++ b/apps/website/.eslintrc.json
@@ -16,6 +16,9 @@
   },
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": ["!**/*"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "warn"
+  },
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Because it is sometimes unavoidable to use `any`  atm -> e.g. when working with `import.meta.glob` or `Component<any>`

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
