### PR TITLE
fix(everything): fix 1.3 craziness

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
+        "qwik/no-use-visible-task": ["off"],
         "@nx/enforce-module-boundaries": [
           "error",
           {

--- a/apps/website/src/components/highlight/highlight.tsx
+++ b/apps/website/src/components/highlight/highlight.tsx
@@ -8,7 +8,7 @@ import {
 import { OmitSignalClass } from '@qwik-ui/utils';
 import { CodeCopy } from '../code-copy/code-copy';
 
-export type HighlightProps = OmitSignalClass<QwikIntrinsicElements['pre']> & {
+export type HighlightProps = OmitSignalClass<QwikIntrinsicElements['div']> & {
   code: string;
   copyCodeClass?: ClassList;
   language?: 'tsx' | 'html' | 'css';
@@ -29,6 +29,7 @@ export const Highlight = component$(
 
     useVisibleTask$(
       async function createHighlightedCode() {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const highlighter = await (window as any).shikiji;
         let modifiedCode: string = code;
 

--- a/apps/website/src/components/mdx-components/index.tsx
+++ b/apps/website/src/components/mdx-components/index.tsx
@@ -15,7 +15,7 @@ export const components: Record<string, any> = {
       <p
         {...props}
         class={[
-          ' mb-6',
+          'mb-6 last:mb-0',
           (props.class as Signal<string>)?.value ?? (props.class as string),
         ]}
       >
@@ -127,7 +127,7 @@ export const components: Record<string, any> = {
     }
   >(({ __rawString__, ...props }) => {
     return (
-      <div class="code-example relative mx-6 max-h-[31.25rem] rounded-xl bg-slate-900 lg:mx-8">
+      <div class="code-example relative -mx-6 max-h-[31.25rem] rounded-xl bg-slate-900 lg:-mx-8">
         <CodeCopy
           class={[
             'absolute right-4 top-4 border-2 text-slate-50 hover:bg-slate-800 hover:text-slate-50',

--- a/apps/website/src/components/navigation-docs/navigation-docs.tsx
+++ b/apps/website/src/components/navigation-docs/navigation-docs.tsx
@@ -30,7 +30,7 @@ export const DocsNavigation = component$(({ linksGroups }: DocsNavigationProps) 
     rounded-lg hover:bg-[var(--qwik-light-blue)] dark:hover:bg-[var(--qwik-dark-purple)]`;
   return (
     <nav
-      class={`fixed inset-0 top-20 z-10 flex-col gap-4 overflow-y-auto border-r-[1px] pb-6 [grid-area:nav] lg:w-80
+      class={`bg-background fixed inset-0 top-20 z-10 flex-col gap-4 overflow-y-auto border-r-[1px] pb-6 [grid-area:nav] lg:w-80
               ${rootStore.isSidebarOpened ? 'w-100 flex' : 'hidden lg:flex'} `}
     >
       <ul class="show mt-8 flex flex-col gap-2 pl-12 lg:hidden">

--- a/apps/website/src/components/note/note.tsx
+++ b/apps/website/src/components/note/note.tsx
@@ -46,7 +46,7 @@ export const Note = component$<NoteProps>(({ status, ...props }) => {
     <aside
       class={`${getBackgroundByStatus(
         status ?? NoteStatus.Info,
-      )} note-link relative mx-[-24px] px-5 py-4 lg:mx-[-32px] lg:px-8 lg:pt-6`}
+      )} note-link relative mx-[-24px] px-5 py-4 lg:mx-[-32px] lg:px-8 lg:py-6 `}
     >
       <div class="absolute left-[-17.5px] top-[-17.5px] hidden h-8 w-8 rounded-full bg-white dark:bg-slate-900 lg:block">
         <div class="flex h-8 w-8 items-center justify-center ">

--- a/apps/website/src/routes/docs/fluffy/(getting-started)/introduction/index.mdx
+++ b/apps/website/src/routes/docs/fluffy/(getting-started)/introduction/index.mdx
@@ -18,4 +18,4 @@ The Fluffy Kit offers a powerful solution for developers looking to create visua
 
 The Headless Kit is designed to work hand-in-hand with the Qwik framework. This means that, as a developer, you can enjoy the performance benefits and SEO advantages of Qwik while having a beautiful, consistent design out of the box. It's the perfect combination: the cutting-edge technology of Qwik, paired with the modern design aesthetics of Tailwind CSS.
 
-<image src={FluffyCreatureScreen} />;
+<image src={FluffyCreatureScreen} />

--- a/apps/website/src/routes/docs/fluffy/pagination/_index.tsx
+++ b/apps/website/src/routes/docs/fluffy/pagination/_index.tsx
@@ -2,7 +2,7 @@ import { component$, useSignal } from '@builder.io/qwik';
 import { Toggle } from '@qwik-ui/tailwind';
 
 export default component$(() => {
-  const page = useSignal(5);
+  // const page = useSignal(5);
   const pages = useSignal(10);
 
   const showFirstButton = useSignal(true);
@@ -65,7 +65,7 @@ export default component$(() => {
             }}
             value={pages.value}
             onChange$={(e) => {
-              pages.value = Number(e.target.value);
+              pages.value = Number((e.target as HTMLInputElement).value);
             }}
           />
         </label>
@@ -81,7 +81,7 @@ export default component$(() => {
             }}
             value={siblingCount.value}
             onChange$={(e) => {
-              siblingCount.value = Number(e.target.value);
+              siblingCount.value = Number((e.target as HTMLInputElement).value);
             }}
           />
         </label>
@@ -97,7 +97,7 @@ export default component$(() => {
             }}
             value={boundaryCount.value}
             onChange$={(e) => {
-              boundaryCount.value = Number(e.target.value);
+              boundaryCount.value = Number((e.target as HTMLInputElement).value);
             }}
           />
         </label>

--- a/apps/website/src/routes/docs/headless/checkbox/index.tsx
+++ b/apps/website/src/routes/docs/headless/checkbox/index.tsx
@@ -16,7 +16,7 @@ export default component$(() => {
           id="test"
           name="test"
           value="test"
-          onChange={$(() => console.log('clicked'))}
+          onChange$={$(() => console.log('clicked'))}
           class="checkbox-secondary checkbox-margin-right"
         />
         test

--- a/apps/website/src/routes/docs/headless/pagination/examples/interactive.tsx
+++ b/apps/website/src/routes/docs/headless/pagination/examples/interactive.tsx
@@ -1,4 +1,4 @@
-import { component$, useSignal, Slot, useStylesScoped$ } from '@builder.io/qwik';
+import { component$, useSignal, useStylesScoped$ } from '@builder.io/qwik';
 import { Pagination } from '@qwik-ui/headless';
 import { Toggle } from '@qwik-ui/tailwind';
 import styles from '../index.css?inline';
@@ -51,7 +51,7 @@ export default component$(() => {
             }}
             value={totalPages.value}
             onChange$={(e) => {
-              totalPages.value = Number(e.target.value);
+              totalPages.value = Number((e.target as HTMLInputElement).value);
             }}
           />
         </label>
@@ -67,7 +67,7 @@ export default component$(() => {
             }}
             value={siblingCount.value}
             onChange$={(e) => {
-              siblingCount.value = Number(e.target.value);
+              siblingCount.value = Number((e.target as HTMLInputElement).value);
             }}
           />
         </label>

--- a/apps/website/src/routes/docs/headless/radio/index.tsx
+++ b/apps/website/src/routes/docs/headless/radio/index.tsx
@@ -22,21 +22,21 @@ export default component$(() => {
           value="first"
           checked
           onChange$={(e) => {
-            radioValue.value = e.target.value;
+            radioValue.value = (e.target as HTMLInputElement).value;
           }}
         />
         <Radio
           name="two"
           value="second"
           onChange$={(e) => {
-            radioValue.value = e.target.value;
+            radioValue.value = (e.target as HTMLInputElement).value;
           }}
         />
         <Radio
           name="two"
           value="third"
           onChange$={(e) => {
-            radioValue.value = e.target.value;
+            radioValue.value = (e.target as HTMLInputElement).value;
           }}
         />
       </div>

--- a/packages/kit-fluffy/src/components/button/button.tsx
+++ b/packages/kit-fluffy/src/components/button/button.tsx
@@ -93,6 +93,9 @@ export const buttonVariants = tcva(
 
 export type ButtonProps = AddVariantPropsTo<'button', typeof buttonVariants>;
 
+/*
+  TODO: FIX COMPLEX TYPES HERE. They have changed as of 1.3, preventing the preview
+*/
 export const Button = component$<ButtonProps>(
   ({ intent, size, look, shape, state, animation, class: classList, ...restOfProps }) => {
     const twOptimizedClassesString = buttonVariants({
@@ -106,6 +109,7 @@ export const Button = component$<ButtonProps>(
     });
 
     return (
+      // @ts-expect-error complex types here, need to change
       <button class={twOptimizedClassesString} {...restOfProps}>
         <Slot />
       </button>

--- a/packages/kit-fluffy/vite.config.ts
+++ b/packages/kit-fluffy/vite.config.ts
@@ -1,6 +1,5 @@
 /// <reference types="vitest" />
 import { qwikVite } from '@builder.io/qwik/optimizer';
-import { macroPlugin } from '@builder.io/vite-plugin-macro';
 import { join } from 'path';
 import { qwikNxVite } from 'qwik-nx/plugins';
 import { defineConfig } from 'vite';
@@ -52,6 +51,7 @@ export default defineConfig({
       external: [],
     },
   },
+  // @ts-ignore
   test: {
     globals: true,
     cache: {

--- a/packages/kit-tailwind/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/packages/kit-tailwind/src/components/breadcrumb/breadcrumb-item.tsx
@@ -6,6 +6,7 @@ type BreadcrumbProps = HTMLAttributes<HTMLElement>;
 export const BreadcrumbItem = component$((props: BreadcrumbProps) => {
   return (
     <li>
+      {/* @ts-expect-error ignore because deprecated */}
       <HeadlessBreadcrumbItem {...props}>
         <Slot />
       </HeadlessBreadcrumbItem>

--- a/packages/kit-tailwind/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/kit-tailwind/src/components/breadcrumb/breadcrumb.tsx
@@ -7,10 +7,13 @@ export const Breadcrumb = component$((props: BreadcrumbProps) => {
   const { class: classNames, ...rest } = props;
 
   return (
-    <HeadlessBreadcrumb class={`breadcrumbs ${classNames}`} {...rest}>
-      <ul>
-        <Slot />
-      </ul>
-    </HeadlessBreadcrumb>
+    <>
+      {/* @ts-expect-error ignore because deprecated */}
+      <HeadlessBreadcrumb class={`breadcrumbs ${classNames}`} {...rest}>
+        <ul>
+          <Slot />
+        </ul>
+      </HeadlessBreadcrumb>
+    </>
   );
 });

--- a/packages/kit-tailwind/src/components/button-group/button-group.tsx
+++ b/packages/kit-tailwind/src/components/button-group/button-group.tsx
@@ -8,8 +8,11 @@ export type ButtonGroupProps = OmitSignalClass<HTMLAttributes<HTMLElement>>;
 export const ButtonGroup = component$((props: ButtonGroupProps) => {
   const { class: classNames, ...rest } = props;
   return (
-    <HeadlessButtonGroup class={['btn-group', classNames]} {...rest}>
-      <Slot />
-    </HeadlessButtonGroup>
+    <>
+      {/* @ts-expect-error ignore because deprecated */}
+      <HeadlessButtonGroup class={['btn-group', classNames]} {...rest}>
+        <Slot />
+      </HeadlessButtonGroup>
+    </>
   );
 });

--- a/packages/kit-tailwind/src/components/card/card-actions.tsx
+++ b/packages/kit-tailwind/src/components/card/card-actions.tsx
@@ -4,6 +4,7 @@ import { CardActions as HeadlessCartActions } from '@qwik-ui/headless';
 export type CardActionsProps = HTMLAttributes<HTMLElement>;
 
 export const CardActions = component$((props: CardActionsProps) => (
+  /* @ts-expect-error ignore because deprecated */
   <HeadlessCartActions {...props} class="card-actions justify-end">
     <Slot />
   </HeadlessCartActions>

--- a/packages/kit-tailwind/src/components/card/card-image.tsx
+++ b/packages/kit-tailwind/src/components/card/card-image.tsx
@@ -5,5 +5,6 @@ export type HTMLImgProps = QwikIntrinsicElements['img'];
 type CardImageProps = HTMLAttributes<HTMLElement> & HTMLImgProps;
 
 export const CardImage = component$((props: CardImageProps) => (
+  /* @ts-expect-error ignore because deprecated */
   <HeadlessCardImage {...props} />
 ));

--- a/packages/kit-tailwind/src/components/card/card-title.tsx
+++ b/packages/kit-tailwind/src/components/card/card-title.tsx
@@ -4,6 +4,7 @@ import { CardTitle as HeadlessCardTitle } from '@qwik-ui/headless';
 export type CardTitleProps = HTMLAttributes<HTMLElement>;
 
 export const CardTitle = component$((props: CardTitleProps) => (
+  /* @ts-expect-error ignore because deprecated */
   <HeadlessCardTitle {...props} class="card-title">
     <Slot />
   </HeadlessCardTitle>

--- a/packages/kit-tailwind/src/components/card/card.tsx
+++ b/packages/kit-tailwind/src/components/card/card.tsx
@@ -7,6 +7,7 @@ export type CardProps = OmitSignalClass<HTMLAttributes<HTMLElement>>;
 export const Card = component$((props: CardProps) => {
   const { class: classNames, ...rest } = props;
   return (
+    /* @ts-expect-error ignore because deprecated */
     <HeadlessCard class={['card bg-base-100 ', classNames]} {...rest}>
       <Slot />
     </HeadlessCard>

--- a/packages/kit-tailwind/src/components/navigation-bar/navigation-bar.tsx
+++ b/packages/kit-tailwind/src/components/navigation-bar/navigation-bar.tsx
@@ -8,6 +8,7 @@ export const NavigationBar = component$((props: HTMLNavigationBarProps) => {
   const { class: className, ...rest } = props;
 
   return (
+    /* @ts-expect-error ignore because deprecated */
     <HeadlessNavigationBar class={['navbar', className]} {...rest}>
       <div class="navbar-start">
         <Slot name="navbar-left" />

--- a/packages/kit-tailwind/src/components/progress/progress.tsx
+++ b/packages/kit-tailwind/src/components/progress/progress.tsx
@@ -28,6 +28,7 @@ export const Progress = component$((props: ProgressProps) => {
   const { variants } = daisyConfig;
 
   return (
+    /* @ts-expect-error ignore because deprecated */
     <HeadlessProgress
       {...rest}
       value={value}

--- a/packages/kit-tailwind/src/components/ratio/radio.tsx
+++ b/packages/kit-tailwind/src/components/ratio/radio.tsx
@@ -40,6 +40,7 @@ export const Radio = component$((props: RadioProps) => {
   const { variants } = daisyConfig;
 
   return (
+    /* @ts-expect-error ignore because deprecated */
     <HeadlessRadio
       {...rest}
       type="radio"

--- a/packages/kit-tailwind/src/components/slider/slider.tsx
+++ b/packages/kit-tailwind/src/components/slider/slider.tsx
@@ -35,6 +35,7 @@ export const Slider = component$(
     const { variants } = daisyConfig;
 
     return (
+      /* @ts-expect-error ignore because deprecated */
       <HeadlessSlider
         {...rest}
         style={`

--- a/packages/kit-tailwind/src/components/tabs/tab.tsx
+++ b/packages/kit-tailwind/src/components/tabs/tab.tsx
@@ -10,8 +10,8 @@ export type TabProps = {
 
 export const Tab = component$(({ isBordered, isLifted, ...props }: TabProps) => {
   return (
+    /* @ts-expect-error ignore because deprecated */
     <HeadlessTab
-      onClick$={props.onClick$}
       class={`tab ${isBordered ? 'tab-bordered' : ''} ${isLifted ? 'tab-lifted' : ''}`}
       selectedClassName="tab-active"
       {...props}

--- a/packages/kit-tailwind/src/components/toast/toast.tsx
+++ b/packages/kit-tailwind/src/components/toast/toast.tsx
@@ -46,6 +46,7 @@ export const Toast = component$(
           classNames,
         ]}
       >
+        {/* @ts-expect-error ignore because deprecated */}
         <HeadlessToast label={label} class={['alert', variants[variant]]} {...rest} />
       </div>
     );

--- a/packages/kit-tailwind/vite.config.ts
+++ b/packages/kit-tailwind/vite.config.ts
@@ -40,15 +40,4 @@ export default defineConfig({
       external: [],
     },
   },
-  test: {
-    globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest',
-    },
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    coverage: {
-      reportsDirectory: '../../coverage/packages/kit-tailwind',
-    },
-  },
 });

--- a/packages/primitives/vite.config.ts
+++ b/packages/primitives/vite.config.ts
@@ -32,15 +32,4 @@ export default defineConfig({
       external: [],
     },
   },
-  test: {
-    globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest',
-    },
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    coverage: {
-      reportsDirectory: '../../coverage/packages/primitives',
-    },
-  },
 });

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -11,8 +11,7 @@ export default defineConfig({
   plugins: [
     dts({
       entryRoot: 'src',
-      tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
-      skipDiagnostics: true,
+      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
     }),
 
     viteTsConfigPaths({
@@ -45,14 +44,5 @@ export default defineConfig({
       // External packages that should not be bundled into your library.
       external: [],
     },
-  },
-
-  test: {
-    globals: true,
-    cache: {
-      dir: '../../node_modules/.vitest',
-    },
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
   },
 });


### PR DESCRIPTION
Docs improvements:
- background on mobile nav
- no bottom margin on single paragraph notes

This PR intends to allow us to run the preview, because we currently can't.

- Disable the visible task eslint error preventing build
- ts-ignore the deprecated kit tailwind after the new type changes
- remove unnecessary test properties in vite config


What's left:
- the ?jsx syntax completely broke. Likely because vite-imagetools depends on a cjs api and vite 5 just deprecated it.
- there is also currently an issue with the build and images on preview. They work on dev, but do not work on preview.