### PR TITLE
RFC feat(aspect-ratio): add aspect-ratio component inspired from radix

### DIFF
--- a/packages/kit-headless/src/components/aspect-ratio/aspect-ratio.tsx
+++ b/packages/kit-headless/src/components/aspect-ratio/aspect-ratio.tsx
@@ -1,0 +1,31 @@
+import { QwikIntrinsicElements, component$, Slot } from '@builder.io/qwik';
+
+type aspectRatioProps = QwikIntrinsicElements['div'] & { ratio?: number };
+
+export const AspectRatio = component$<aspectRatioProps>(({ ratio = 1 / 1, ...props }) => {
+  return (
+    <div
+      style={{
+        // ensures inner element is contained
+        position: 'relative',
+        // ensures padding bottom trick maths works
+        width: '100%',
+        paddingBottom: `${100 / ratio}%`,
+      }}
+    >
+      <div
+        {...props}
+        style={{
+          ...(props.style as object),
+          // ensures children expand in ratio
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+        }}
+      />
+      <Slot />
+    </div>
+  );
+});


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

API is inspired by Radix. I guess they don't have this component for nothing :sweat_smile: . Probably useful to keep the right aspect-ratio in certain situations :stuck_out_tongue: 

I didn't make any test for it, but I guess this can (mostly) be copied from radix as well.

Would also require writing some docs, but I'd like to know what you guys think first.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
