### PR TITLE
Replace css vars with tw slate for all accordion examples

### DIFF
--- a/apps/website/src/routes/docs/headless/accordion/examples/custom-heading.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/custom-heading.tsx
@@ -11,10 +11,10 @@ export default component$(() => {
   return (
     <>
       <div class="flex w-full justify-center">
-        <AccordionRoot class="w-[min(400px,_100%)]">
-          <AccordionItem class="border-b">
+        <AccordionRoot class="w-[min(400px,_100%)] bg-slate-950 text-slate-50">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h4">
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4  text-left hover:underline">
                 <span>I'm an h4</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -24,12 +24,12 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">My Heading is an h4!</p>
+              <p class=" bg-slate-950 p-4">My Heading is an h4!</p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h5">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline">
                 <span>I'm an h5</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -39,12 +39,12 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">My Heading is an h5!</p>
+              <p class=" bg-slate-950 p-4">My Heading is an h5!</p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h6">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline aria-expanded:rounded-none">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline aria-expanded:rounded-none">
                 <span>I'm an h6</span>
                 <span class="flex pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -54,7 +54,7 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">My Heading is an h6!</p>
+              <p class=" bg-slate-950 p-4">My Heading is an h6!</p>
             </AccordionContent>
           </AccordionItem>
         </AccordionRoot>

--- a/apps/website/src/routes/docs/headless/accordion/examples/default-value.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/default-value.tsx
@@ -11,10 +11,10 @@ export default component$(() => {
   return (
     <>
       <div class="flex w-full justify-center">
-        <AccordionRoot class="w-[min(400px,_100%)]">
-          <AccordionItem class="border-b">
+        <AccordionRoot class="w-[min(400px,_100%)] bg-slate-950 text-slate-50">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4  text-left hover:underline">
                 <span>Not open by default.</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -24,12 +24,12 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">I wasn't open by default!</p>
+              <p class=" bg-slate-950 p-4">I wasn't open by default!</p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem defaultValue>
+          <AccordionItem defaultValue class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline">
                 <span>I'm open!</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -39,15 +39,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 You can open me by default by putting the <strong>defaultValue</strong>{' '}
                 prop on the Accordion Item.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <h3>
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline aria-expanded:rounded-none">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline aria-expanded:rounded-none">
                 <span>Not open by default.</span>
                 <span class="flex pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -57,7 +57,7 @@ export default component$(() => {
               </AccordionTrigger>
             </h3>
             <AccordionContent>
-              <p class="pb-4">I wasn't open by default!</p>
+              <p class=" bg-slate-950 p-4">I wasn't open by default!</p>
             </AccordionContent>
           </AccordionItem>
         </AccordionRoot>

--- a/apps/website/src/routes/docs/headless/accordion/examples/disabled.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/disabled.tsx
@@ -12,10 +12,10 @@ export default component$(() => {
   return (
     <>
       <div class="flex w-full justify-center">
-        <AccordionRoot class="w-[min(400px,_100%)]">
-          <AccordionItem class="border-b">
+        <AccordionRoot class="w-[min(400px,_100%)] bg-slate-950 text-slate-50">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4  text-left hover:underline">
                 <span>I'm enabled!</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -25,15 +25,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 Hey, I'm enabled! This is because I don't use the{' '}
                 <strong>disabled</strong> prop on the trigger.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline">
                 <span>I'm enabled!</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -43,23 +43,20 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 Hey, I'm enabled! This is because I don't use the{' '}
                 <strong>disabled</strong> prop on the trigger.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950 bg-slate-700">
             <h3>
               <AccordionTrigger
                 disabled
-                class="hover:bg-accent/50 group flex w-full items-center justify-between py-4 text-left aria-disabled:cursor-not-allowed aria-expanded:rounded-none"
+                class="group flex w-full items-center justify-between p-4 text-left  hover:bg-slate-500 aria-disabled:cursor-not-allowed aria-expanded:rounded-none"
               >
                 <span>
-                  I'm{' '}
-                  <span class="font-bold" style="color: red">
-                    disabled!
-                  </span>
+                  I'm <span class="bg-red-600 p-1 font-bold">disabled!</span>
                 </span>
                 <span class="flex pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -69,7 +66,7 @@ export default component$(() => {
               </AccordionTrigger>
             </h3>
             <AccordionContent>
-              <p class="pb-4">You shouldn't be able to see this!</p>
+              <p class=" bg-slate-950 p-4">You shouldn't be able to see this!</p>
             </AccordionContent>
           </AccordionItem>
         </AccordionRoot>

--- a/apps/website/src/routes/docs/headless/accordion/examples/dynamic.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/dynamic.tsx
@@ -53,16 +53,20 @@ export default component$(({ itemsLength = 3 }: DynamicAccordionProps) => {
           </label>
         </div>
 
-        <AccordionRoot class="w-[min(400px,_100%)]">
+        <AccordionRoot class="w-[min(400px,_100%)] text-slate-50">
           {itemStore.map(({ label, id }, index) => {
+            const firstItem = index === 0;
+            const className = firstItem
+              ? 'bg-slate-700 p-4 group flex w-full items-center justify-between rounded-t-sm  text-left hover:underline'
+              : 'bg-slate-700 p-4 group flex w-full items-center justify-between   text-left hover:underline';
             return (
-              <AccordionItem id={`${id}`} key={id} class="border-b">
+              <AccordionItem id={`${id}`} key={id} class="border-b border-slate-950">
                 <AccordionHeader>
-                  <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm py-4 text-left hover:underline">
-                    {label}
-                  </AccordionTrigger>
+                  <AccordionTrigger class={className}>{label}</AccordionTrigger>
                 </AccordionHeader>
-                <AccordionContent class="py-4 pt-0">index: {index}</AccordionContent>
+                <AccordionContent class="bg-slate-950 p-4">
+                  index: {index}
+                </AccordionContent>
               </AccordionItem>
             );
           })}

--- a/apps/website/src/routes/docs/headless/accordion/examples/focused-index.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/focused-index.tsx
@@ -14,14 +14,14 @@ export default component$(() => {
     <>
       <div class="flex w-full flex-col items-center gap-4">
         <AccordionRoot
-          class="w-[min(400px,_100%)]"
+          class="w-[min(400px,_100%)] bg-slate-950 text-slate-50"
           onFocusIndexChange$={(index) => {
             focusedIndexSig.value = index;
           }}
         >
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader>
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4  text-left hover:underline">
                 <span>Is Qwik Production Ready?</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -31,14 +31,14 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 Yes! Since 1.0 back in May, Qwik apps are great for production.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader>
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline">
                 <span>Why is Qwik so fast?</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -48,15 +48,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 Because you're doing less work! Thanks to resumability we execute
                 JavaScript on interaction.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader>
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline aria-expanded:rounded-none">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline aria-expanded:rounded-none">
                 <span>What if I want to use React?</span>
                 <span class="flex pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -66,7 +66,7 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 Check out Qwik-React! It allows you to partially hydrate React components
                 into your Qwik app.
               </p>

--- a/apps/website/src/routes/docs/headless/accordion/examples/hero.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/hero.tsx
@@ -12,10 +12,14 @@ export default component$(() => {
   return (
     <>
       <div class="flex w-full justify-center">
-        <AccordionRoot animated enhance={true} class="w-[min(400px,_100%)]">
-          <AccordionItem class="border-b">
+        <AccordionRoot
+          animated
+          enhance={true}
+          class="w-[min(400px,_100%)] bg-slate-950 text-slate-50"
+        >
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4 py-4 text-left hover:underline">
                 <span>Can I add headings inside the accordion?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -23,15 +27,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class="bg-slate-950 p-4 pb-4">
                 Yes, if you wrap the <strong>AccordionHeader</strong> component around the
                 trigger, screen readers will announce it properly.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4 py-4 text-left hover:underline">
                 <span>Is it easy to animate?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -39,15 +43,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class="bg-slate-950 p-4 pb-4">
                 Yup! You can even use animations or CSS transitions using the{' '}
                 <strong>animated</strong> prop on the accordion root!
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline aria-expanded:rounded-none">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4 py-4 text-left hover:underline aria-expanded:rounded-none">
                 <span>How about opening multiple items?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -55,7 +59,7 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class="bg-slate-950 p-4 pb-4">
                 You can do that by setting the <strong>behavior</strong> prop to "multi"
                 on the Accordion
               </p>

--- a/apps/website/src/routes/docs/headless/accordion/examples/multi.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/multi.tsx
@@ -12,10 +12,15 @@ export default component$(() => {
   return (
     <>
       <div class="flex w-full justify-center">
-        <AccordionRoot collapsible animated behavior="multi" class="w-[min(400px,_100%)]">
-          <AccordionItem class="border-b">
+        <AccordionRoot
+          collapsible
+          animated
+          behavior="multi"
+          class="w-[min(400px,_100%)] bg-slate-950 text-slate-50"
+        >
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm  py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4   text-left hover:underline">
                 <span>Can I style based on the trigger state?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -23,7 +28,7 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 100%. The trigger has a <strong>[data-state]</strong> selector that can be
                 styled when equal to the <strong>open</strong> or <strong>closed</strong>{' '}
                 values.
@@ -33,9 +38,9 @@ export default component$(() => {
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline">
                 <span>What about applying attributes?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -43,15 +48,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 It's typed using <strong>QwikIntrinsicElements</strong>, meaning you can
                 treat it like an element!
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline aria-expanded:rounded-none">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline aria-expanded:rounded-none">
                 <span>How about using event handlers?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -59,7 +64,7 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 You can use onClick$, onKeyDown$, any handlers you'd normally use with
                 Qwik!
               </p>

--- a/apps/website/src/routes/docs/headless/accordion/examples/non-collapsible.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/non-collapsible.tsx
@@ -13,10 +13,14 @@ export default component$(() => {
   return (
     <>
       <div class="flex w-full justify-center">
-        <AccordionRoot animated collapsible={false} class="w-[min(400px,_100%)]">
-          <AccordionItem class="border-b">
+        <AccordionRoot
+          animated
+          collapsible={false}
+          class="w-[min(400px,_100%)] bg-slate-950 text-slate-50"
+        >
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm  py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4   text-left hover:underline">
                 <span>How do I turn off collapsing?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -24,15 +28,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 You can turn it off by setting the <strong>collapsible</strong> prop to
                 false.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader as="h3">
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline">
                 <span>Can it be dynamic?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -40,12 +44,14 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">Yes, there's a dynamic section further below.</p>
+              <p class=" bg-slate-950 p-4">
+                Yes, there's a dynamic section further below.
+              </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <h3>
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline aria-expanded:rounded-none">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline aria-expanded:rounded-none">
                 <span>Can I reactively change stuff?</span>
                 <span class="pl-2">
                   <SVG class="ease transition-transform duration-500 group-aria-expanded:rotate-180 group-aria-expanded:transform" />
@@ -53,7 +59,7 @@ export default component$(() => {
               </AccordionTrigger>
             </h3>
             <AccordionContent class="accordion-animation-1 overflow-hidden">
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 Of course! You can also use the onFocusIndexChange$ and
                 onSelectedIndexChange$ custom events.
               </p>

--- a/apps/website/src/routes/docs/headless/accordion/examples/selected-index.tsx
+++ b/apps/website/src/routes/docs/headless/accordion/examples/selected-index.tsx
@@ -14,14 +14,14 @@ export default component$(() => {
     <>
       <div class="flex w-full flex-col items-center gap-4">
         <AccordionRoot
-          class="w-[min(400px,_100%)]"
+          class="w-[min(400px,_100%)] bg-slate-950 text-slate-50"
           onSelectedIndexChange$={(index) => {
             selectedIndexSig.value = index;
           }}
         >
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader>
-              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between rounded-t-sm bg-slate-700 p-4  text-left hover:underline">
                 <span>Can I contribute to Qwik UI?</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -31,14 +31,14 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 Absolutely! You can reach out to us in the Qwikifiers discord.
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader>
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline">
                 <span>How many people are learning Qwik?</span>
                 <span class="pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -48,15 +48,15 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">
+              <p class=" bg-slate-950 p-4">
                 According to the 2023 <strong>stack overflow survey</strong>, it's close
                 to the amount of people learning Remix already!
               </p>
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem class="border-b">
+          <AccordionItem class="border-b border-slate-950">
             <AccordionHeader>
-              <AccordionTrigger class="group flex w-full items-center justify-between py-4 text-left hover:underline aria-expanded:rounded-none">
+              <AccordionTrigger class="group flex w-full items-center justify-between bg-slate-700 p-4  text-left hover:underline aria-expanded:rounded-none">
                 <span>What's the Qwikifiers discord?</span>
                 <span class="flex pl-2">
                   <p class="scale-150 group-aria-expanded:rotate-45 group-aria-expanded:transform">
@@ -66,7 +66,9 @@ export default component$(() => {
               </AccordionTrigger>
             </AccordionHeader>
             <AccordionContent>
-              <p class="pb-4">A group of active contributors in the Qwik ecosystem!</p>
+              <p class=" bg-slate-950 p-4">
+                A group of active contributors in the Qwik ecosystem!
+              </p>
             </AccordionContent>
           </AccordionItem>
         </AccordionRoot>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement

# Description

Makes code more "copy & paste" friendly by changing all the css-vars to tw slates. 

# Screenshots/Demo
New version (most drastic example): 
![new-version](https://github.com/qwikifiers/qwik-ui/assets/102767512/8970fedd-40bd-4f28-b48a-52465f5416a1)
Current version:
![current-version](https://github.com/qwikifiers/qwik-ui/assets/102767512/a8588fbc-671d-462c-bb69-3ab9ee274d0f)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

