### PR TITLE
fix(header.tsx): flashing theme icon when switching pages in dark mode

### DIFF
--- a/apps/website/src/components/header/header.tsx
+++ b/apps/website/src/components/header/header.tsx
@@ -106,7 +106,12 @@ export default component$(
         </nav>
 
         <button type="button" aria-label="Toggle dark mode" onClick$={toggleDarkMode}>
-          {rootStore.mode === 'dark' ? <MoonIcon /> : <SunIcon />}
+          <div class="hidden dark:block">
+            <MoonIcon />
+          </div>
+          <div class="block dark:hidden ">
+            <SunIcon />
+          </div>
         </button>
         <a
           target="_blank"


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Fixes flashing light-theme icon when changing pages in dark mode. 

# Use cases and why
- 1. More refined user experience

# Screenshots/Demo
https://github.com/qwikifiers/qwik-ui/assets/102767512/8bec014c-3cff-446f-b6d5-62eac62fb417

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
