### PR TITLE
refactor(navigation-docs): make <a> wrap <li> instead of <li> wrap <a>

### DIFF
--- a/apps/website/src/components/navigation-docs/navigation-docs.tsx
+++ b/apps/website/src/components/navigation-docs/navigation-docs.tsx
@@ -26,7 +26,7 @@ export const DocsNavigation = component$(({ linksGroups }: DocsNavigationProps) 
   const location = useLocation();
   const rootStore = useAppState();
   const selectedKitSig = useSelectedKit();
-  const linkStyles = `px-4 py-2 -ml-4 mr-8 text-xl lg:text-sm flex items-center 
+  const linkStyles = `px-4 py-2 -ml-4 mr-8 text-xl lg:text-sm flex items-center
     rounded-lg hover:bg-[var(--qwik-light-blue)] dark:hover:bg-[var(--qwik-dark-purple)]`;
   return (
     <nav
@@ -34,25 +34,23 @@ export const DocsNavigation = component$(({ linksGroups }: DocsNavigationProps) 
               ${rootStore.isSidebarOpened ? 'w-100 flex' : 'hidden lg:flex'} `}
     >
       <ul class="show mt-8 flex flex-col gap-2 pl-12 lg:hidden">
-        <li class={linkStyles}>
-          <a href="/about">About</a>
-        </li>
+        <a href="/about">
+          <li class={linkStyles}>About</li>
+        </a>
         {selectedKitSig.value !== KitName.HEADLESS && (
-          <li class={linkStyles}>
-            <a href="/docs/headless/introduction">Headless Kit</a>
-          </li>
+          <a href="/docs/headless/introduction">
+            <li class={linkStyles}>Headless Kit</li>
+          </a>
         )}
         {rootStore.featureFlags?.showFluffy &&
           selectedKitSig.value !== KitName.FLUFFY && (
-            <li class={linkStyles}>
-              <a href="/docs/fluffy/introduction">Styled Kit</a>
-            </li>
+            <a href="/docs/fluffy/introduction">
+              <li class={linkStyles}>Styled Kit</li>
+            </a>
           )}
-        <li class={linkStyles}>
-          <a href="https://discord.gg/PVWUUejrez" target="_blank">
-            Community
-          </a>
-        </li>
+        <a href="https://discord.gg/PVWUUejrez" target="_blank">
+          <li class={linkStyles}>Community</li>
+        </a>
         {/* <a href="/contact">Contact</a> */}
       </ul>
       {linksGroups?.map((group) => {


### PR DESCRIPTION

# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests

# Description
This change improves the "click" behaviror. Because of current wrapping sequence, you must click on the text instead of the container to trigger url. Now clicking on the container, or text, will trigger url.



# Use cases and why
More uniform behavior across navigation component.


# Screenshots/Demo
https://github.com/qwikifiers/qwik-ui/assets/102767512/2943b952-29f1-41ca-bda4-b6047285c105


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
