### PR TITLE
revert(fluffy input): re-add component with fixed types and cn helper

### DIFF
--- a/packages/kit-fluffy/src/components/input/input.tsx
+++ b/packages/kit-fluffy/src/components/input/input.tsx
@@ -1,0 +1,16 @@
+import { QwikIntrinsicElements, component$ } from '@builder.io/qwik';
+import { cn } from '@qwik-ui/utils';
+
+export type InputProps = QwikIntrinsicElements['input'];
+
+export const Input = component$<InputProps>(({ ...props }) => {
+  return (
+    <input
+      {...props}
+      class={cn(
+        'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        props.class,
+      )}
+    />
+  );
+});


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Screenshots/Demo

<!-- Add your screenshots here -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
