### PR TITLE
fix(preservemodules): temporarily remove preserveModules

### DIFF
--- a/packages/kit-headless/vite.config.ts
+++ b/packages/kit-headless/vite.config.ts
@@ -66,10 +66,6 @@ export default defineConfig({
         ...excludeAll(dependencies),
         ...excludeAll(peerDependencies),
       ],
-      output: {
-        preserveModules: true,
-        preserveModulesRoot: 'packages/kit-headless/src',
-      },
     },
   },
 });

--- a/packages/kit-headless/vite.config.ts
+++ b/packages/kit-headless/vite.config.ts
@@ -66,6 +66,10 @@ export default defineConfig({
         ...excludeAll(dependencies),
         ...excludeAll(peerDependencies),
       ],
+      // output: {
+      //   preserveModules: true,
+      //   preserveModulesRoot: 'packages/kit-headless/src',
+      // },
     },
   },
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

For two reasons:

- the namespace issues (see https://github.com/qwikifiers/qwik-ui/pull/521 which also links to https://github.com/qwikifiers/qwik-ui/issues/519 for a more thorough explanation)
- the SSG build hang issue (see https://github.com/qwikifiers/qwik-ui/issues/577 wich is likely the same bug as https://github.com/qwikifiers/qwik-ui/issues/519)

Until https://github.com/BuilderIO/qwik/issues/5473 gets solved in Qwik, I say we temporarily disable preserveModules. We will have less performance (it should be about 11kb more instead of 40 now that the repo is cleaned up) in favor of more stability.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm changeset` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
