### PR TITLE
fix(dialog): ESC freezes browser

### DIFF
--- a/packages/kit-headless/src/components/modal/modal.tsx
+++ b/packages/kit-headless/src/components/modal/modal.tsx
@@ -88,6 +88,11 @@ export const Modal = component$((props: ModalProps) => {
       {...props}
       role={props.alert === true ? 'alertdialog' : 'dialog'}
       ref={modalRefSig}
+      onKeyDown$={(event) => {
+        if (event.key === 'Escape') {
+          showSig.value = false;
+        }
+      }}
       onClick$={(event) => closeOnBackdropClick$(event)}
     >
       <Slot />


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?
when you press Enter then ESC the dialog will be out of sync with the signal