### PR TITLE
fix(website): add back missing cloudflare adapter (likely caused by n…

### DIFF
--- a/apps/website/adapters/cloudflare-pages/vite.config.ts
+++ b/apps/website/adapters/cloudflare-pages/vite.config.ts
@@ -1,0 +1,25 @@
+import { cloudflarePagesAdapter } from '@builder.io/qwik-city/adapters/cloudflare-pages/vite';
+import { extendConfig } from '@builder.io/qwik-city/vite';
+import baseConfig from '../../vite.config';
+
+/** 
+  @builder.io/qwik & @builder.io/qwik-city 1.4.5 seem to be using vite 5.1.4 as a dep, which causes a build hang, we downgraded, but still an interesting type mismatch because of that here.
+*/
+// @ts-expect-error
+export default extendConfig(baseConfig, () => {
+  return {
+    build: {
+      ssr: true,
+      rollupOptions: {
+        input: ['apps/website/src/entry.cloudflare-pages.tsx', '@qwik-city-plan'],
+      },
+    },
+    plugins: [
+      cloudflarePagesAdapter({
+        // ssg: {
+        //   include: ['/*'],
+        // }
+      }),
+    ],
+  };
+});


### PR DESCRIPTION
…x migration)

# What is it?

Fixing website build, it's likely that the nx migration to v18 accidentally deleted the cloudflare pages adapter's vite config.

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm changeset` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
