### PR TITLE
docs: fix height of `copy-css`

### DIFF
--- a/apps/website/src/components/copy-css-config/copy-css-config.tsx
+++ b/apps/website/src/components/copy-css-config/copy-css-config.tsx
@@ -30,7 +30,7 @@ export default component$(() => {
       </Button>
       <Modal
         bind:show={showSig}
-        class="my-animation bg-background text-foreground rounded-base max-w-2xl overflow-x-hidden p-8 shadow-md backdrop:backdrop-blur backdrop:backdrop-brightness-50 dark:backdrop:backdrop-brightness-100"
+        class="my-animation bg-background text-foreground rounded-base h-full max-w-2xl overflow-x-hidden p-8 shadow-md backdrop:backdrop-blur backdrop:backdrop-brightness-50 dark:backdrop:backdrop-brightness-100"
       >
         <ModalHeader>
           <h2 class="text-lg font-bold">Copy config</h2>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests
- [ ] Other

# Why is it needed?

- the height  of `Copy Code` section was more than 100vh. 

before:
![Screenshot from 2024-04-05 00-25-10](https://github.com/qwikifiers/qwik-ui/assets/79452224/11efd065-5ae5-4cdb-9c57-437cab6c313b)

after:
![Screenshot from 2024-04-05 00-25-24](https://github.com/qwikifiers/qwik-ui/assets/79452224/21a9af6d-b90d-4fca-af3c-7e8f512620df)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
