### PR TITLE
doc: fix skeleton text

### DIFF
--- a/apps/website/src/routes/docs/styled/skeleton/index.mdx
+++ b/apps/website/src/routes/docs/styled/skeleton/index.mdx
@@ -8,7 +8,7 @@ import { statusByComponent } from '~/_state/component-statuses';
 
 # Skeleton
 
-Visually or semantically separates content.
+Skeleton placeholders are temporary content layout previews.
 
 <Showcase name="hero" />
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests
- [ ] Other

# Why is it needed?

Skeleton currently has the text from separator.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
