### PR TITLE
docs: modal: change onHide to onClose

### DIFF
--- a/apps/website/src/routes/docs/headless/modal/index.mdx
+++ b/apps/website/src/routes/docs/headless/modal/index.mdx
@@ -271,10 +271,10 @@ The current solution across framework ecosystems, is to open the Modal eagerly o
       info: `PropsOf<'dialog'>`,
     },
     {
-      name: 'onHide()$',
+      name: 'onClose()$',
       type: 'function',
       info: '() => void',
-      description: 'An event hook that gets notified whenever the modal gets hidden.',
+      description: 'An event hook that gets notified whenever the modal gets closed.',
     },
     {
       name: 'onShow()$',


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests
- [ ] Other

# Why is it needed?

Modal event hook is onClose not onHide anymore

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have ran `pnpm change` and documented my changes
- [X] I have add necessary docs (if needed)
- [X] Added new tests to cover the fix / functionality
