### PR TITLE
feat: bind:open prop on select

### DIFF
--- a/.changeset/breezy-crabs-film.md
+++ b/.changeset/breezy-crabs-film.md
@@ -1,0 +1,5 @@
+---
+'@qwik-ui/headless': patch
+---
+
+feat: Adding the bind:open signal prop to the select component can now reactively control the select listbox open state

--- a/apps/website/src/routes/docs/headless/select/examples/bind-open.tsx
+++ b/apps/website/src/routes/docs/headless/select/examples/bind-open.tsx
@@ -1,0 +1,34 @@
+import { component$, useSignal, useStyles$ } from '@builder.io/qwik';
+import {
+  Select,
+  SelectListbox,
+  SelectOption,
+  SelectPopover,
+  SelectTrigger,
+  SelectValue,
+} from '@qwik-ui/headless';
+import styles from '../snippets/select.css?inline';
+
+export default component$(() => {
+  useStyles$(styles);
+  const users = ['Tim', 'Ryan', 'Jim', 'Jessie', 'Abby'];
+  const isOpen = useSignal(false);
+
+  return (
+    <>
+      <button onClick$={() => (isOpen.value = true)}>Toggle open state</button>
+      <Select bind:open={isOpen} class="select" aria-label="hero">
+        <SelectTrigger class="select-trigger">
+          <SelectValue placeholder="Select an option" />
+        </SelectTrigger>
+        <SelectPopover class="select-popover">
+          <SelectListbox class="select-listbox">
+            {users.map((user) => (
+              <SelectOption key={user}>{user}</SelectOption>
+            ))}
+          </SelectListbox>
+        </SelectPopover>
+      </Select>
+    </>
+  );
+});

--- a/apps/website/src/routes/docs/headless/select/index.mdx
+++ b/apps/website/src/routes/docs/headless/select/index.mdx
@@ -173,9 +173,13 @@ We can pass reactive state by using the `bind:value` prop to the `<Select />` ro
 
 <Showcase name="controlled" />
 
-`bind:value` is a signal prop, it allows us to programmatically control the selected value of the select component.
+`bind:value` is a signal prop, it allows us to reactively control the selected value of the select component.
 
 > Signal props enables two-way data binding efficiently without the common issues of change detection in other frameworks.
+
+We can also reactively control the open state of the select component by using the `bind:open` signal prop.
+
+<Showcase name="bind-open" />
 
 ### Programmatic changes
 

--- a/packages/kit-headless/src/components/select/select.test.ts
+++ b/packages/kit-headless/src/components/select/select.test.ts
@@ -972,6 +972,18 @@ test.describe('Props', () => {
       await expect(getHiddenOptionAt(1)).toHaveAttribute('data-highlighted');
       await expect(getHiddenOptionAt(1)).toHaveAttribute('aria-selected', 'true');
     });
+
+    test(`GIVEN a controlled closed select with a bind:open prop on the root component
+    WHEN the bind:open signal changes to true
+    THEN the listbox should open to reflect the new signal value`, async ({ page }) => {
+      const { driver: d } = await setup(page, 'bind-open');
+
+      await expect(d.getListbox()).toBeHidden();
+
+      page.getByRole('button', { name: 'Toggle open state' }).click();
+
+      await expect(d.getListbox()).toBeVisible();
+    });
   });
 
   test.describe('option value', () => {

--- a/packages/kit-headless/src/components/select/select.tsx
+++ b/packages/kit-headless/src/components/select/select.tsx
@@ -30,8 +30,11 @@ export type SelectProps = PropsOf<'div'> & {
   /** The initial selected value (uncontrolled). */
   value?: string;
 
-  /** A signal that contains the current selected value (controlled). */
+  /** A signal that controls the current selected value (controlled). */
   'bind:value'?: Signal<string>;
+
+  /** A signal that controls the current open state (controlled). */
+  'bind:open'?: Signal<boolean>;
 
   /**
    * QRL handler that runs when a select value changes.
@@ -134,6 +137,12 @@ export const SelectImpl = component$<SelectProps & InternalSelectProps>(
         selectedIndexSig.value = matchingIndex;
         highlightedIndexSig.value = matchingIndex;
       }
+    });
+
+    useTask$(function reactiveOpenTask({ track }) {
+      const signalValue = track(() => props['bind:open']?.value);
+
+      isListboxOpenSig.value = signalValue ?? isListboxOpenSig.value;
     });
 
     useTask$(async function onChangeTask({ track }) {


### PR DESCRIPTION
# What is it?

This PR allows consumers to programmatically control when the select opens or closes. This can be useful for a multi-step form, or other custom behaviors.

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [x] I have add necessary docs (if needed)
- [x] Added new tests to cover the fix / functionality
