### PR TITLE
chore(website vite.config): add  visible chunk names to rollupOptions…

### DIFF
--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -4,11 +4,29 @@ import { qwikVite } from '@builder.io/qwik/optimizer';
 import { qwikNxVite } from 'qwik-nx/plugins';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import { isDev } from '@builder.io/qwik/build';
 import { recmaProvideComponents } from './recma-provide-components';
 
 export default defineConfig(async () => {
   const { default: rehypePrettyCode } = await import('rehype-pretty-code');
   const { visit } = await import('unist-util-visit');
+  let output: any = {};
+  if (!isDev) {
+    // Client-specific configuration
+    output = {
+      // Customize the client build structure
+      entryFileNames: ({ name }: any) => {
+        if (name.startsWith('entry')) {
+          return '[name].js';
+        }
+        return `build/[name]-[hash].js`;
+      },
+      chunkFileNames: () => {
+        return `build/[name]-[hash].js`;
+      },
+      assetFileNames: `build/[name]-[hash].[ext]`,
+    };
+  }
 
   return {
     plugins: [
@@ -78,6 +96,9 @@ export default defineConfig(async () => {
     },
     build: {
       target: 'es2022',
+      rollupOptions: {
+        output,
+      },
     },
     preview: {
       headers: {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [x] Other

# Why is it needed?

This allows seeing the chunk file names instead of `q-[hash].js` in preview or production:

<img width="1470" alt="image" src="https://github.com/qwikifiers/qwik-ui/assets/45822175/5168dbae-dec9-44ba-921b-0c3abb2a182a">

This is a bit of a hack, but I think it will be helpful to have this, maybe up until v1, so that we have better visibility into what's happening when looking up the network tab.

I'll try to create a Qwik-City PR at some point to make this happen when setting `qwikVite.debug` to true.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
