### PR TITLE
fix(headless modal): prevent bubbling of animationend and transitionend event listeners

### DIFF
--- a/packages/kit-headless/src/components/modal/use-modal.tsx
+++ b/packages/kit-headless/src/components/modal/use-modal.tsx
@@ -21,11 +21,13 @@ export function useModal() {
     if (animationDuration !== '0s') {
       modal.addEventListener(
         'animationend',
-        () => {
-          delete modal.dataset.closing;
-          modal.classList.remove('modal-closing');
-          enableBodyScroll(modal);
-          modal.close();
+        (e) => {
+          if (e.target === modal) {
+            delete modal.dataset.closing;
+            modal.classList.remove('modal-closing');
+            enableBodyScroll(modal);
+            modal.close();
+          }
         },
         { once: true },
       );
@@ -33,11 +35,13 @@ export function useModal() {
     if (transitionDuration !== '0s') {
       modal.addEventListener(
         'transitionend',
-        () => {
-          delete modal.dataset.closing;
-          modal.classList.remove('modal-closing');
-          enableBodyScroll(modal);
-          modal.close();
+        (e) => {
+          if (e.target === modal) {
+            delete modal.dataset.closing;
+            modal.classList.remove('modal-closing');
+            enableBodyScroll(modal);
+            modal.close();
+          }
         },
         { once: true },
       );


### PR DESCRIPTION

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?


`transitionend` and `animationend` events were apparently being triggered on dialog children as well.

Here's a recording where you can see me closing the modal normally by pressing escape once and clicking on the backdrop twice. But then I hover over the border-radius 0 button which has a `transition-all duration-100`class that triggers the event callback (in this case just by hovering on the button, but it could happen on click as well). 
https://github.com/qwikifiers/qwik-ui/assets/45822175/8cb5cc2b-1e80-45ab-802d-5676b11c2cf6

Here's the expanded animationend event object when clicking on the backdrop:
<img width="1470" alt="image" src="https://github.com/qwikifiers/qwik-ui/assets/45822175/2f483bf5-8562-4eb0-8d05-0d880e851bf1">

Here's the expanded transitionend event object when hovering on the button:
<img width="1470" alt="image" src="https://github.com/qwikifiers/qwik-ui/assets/45822175/ac47cb71-a1b0-4a3b-9ca7-ff1385df9b15">

As you can see the target the first time is the dialog element, whereas the second time it's the button 😱

So this PR makes sure that the events don't bubble and only happen when the transitions or animations happen on the dialog.

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
