### PR TITLE
fix: input and bind:value

### DIFF
--- a/.changeset/fast-actors-report.md
+++ b/.changeset/fast-actors-report.md
@@ -105,6 +105,10 @@ export default component$(() => {
 
 - Programmatically toggling the popover is still possible, make sure to put the same id on the `<Popover.Root />` that is passed to the `usePopover` hook. Refer to the docs for more info.
 
+- popover-showing and popover-closing classes have been deprecated. Please use the `data-open` and ``data-closing` attributes instead.
+
+- The `data-open`, `data-closing`, and `data-closed` data attributes have been added to the popover.
+
 #### <Popover.Root />
 
 There is a new root compomnent. Configurable props have been moved to the root component.

--- a/apps/website/src/routes/docs/styled/input/examples/hero.tsx
+++ b/apps/website/src/routes/docs/styled/input/examples/hero.tsx
@@ -4,7 +4,7 @@ import { Input } from '~/components/ui';
 export default component$(() => {
   return (
     <>
-      <Input type="email" placeholder="Email" />
+      <Input type="email" placeholder="Email" value="test@test.com" />
     </>
   );
 });

--- a/apps/website/src/routes/docs/styled/input/examples/hero.tsx
+++ b/apps/website/src/routes/docs/styled/input/examples/hero.tsx
@@ -2,5 +2,9 @@ import { component$ } from '@builder.io/qwik';
 import { Input } from '~/components/ui';
 
 export default component$(() => {
-  return <Input type="email" placeholder="Email" />;
+  return (
+    <>
+      <Input type="email" placeholder="Email" />
+    </>
+  );
 });

--- a/packages/kit-styled/src/components/input/input.tsx
+++ b/packages/kit-styled/src/components/input/input.tsx
@@ -1,4 +1,4 @@
-import { component$, type PropsOf } from '@builder.io/qwik';
+import { component$, useSignal, type PropsOf } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 type InputProps = PropsOf<'input'> & {
@@ -16,13 +16,19 @@ export const Input = component$<InputProps>(
     ...props
   }) => {
     const inputId = id || name;
+    const inputRef = useSignal<HTMLInputElement>();
+
+    // TODO: remove this when we can figure out why the optimizer forces you to have a signal rather than conditionally adding the bind:value prop.
+    const dummySig = useSignal('');
+
     return (
       <>
         <input
           {...props}
           aria-errormessage={`${inputId}-error`}
           aria-invalid={!!error}
-          bind:value={valueSig}
+          bind:value={valueSig ? valueSig : dummySig}
+          ref={inputRef}
           class={cn(
             'flex h-12 w-full rounded-base border border-input bg-background px-3 py-1 text-sm text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
             props.class,

--- a/packages/kit-styled/src/components/input/input.tsx
+++ b/packages/kit-styled/src/components/input/input.tsx
@@ -10,6 +10,7 @@ export const Input = component$<InputProps>(
     name,
     error,
     'bind:value': valueSig,
+    value,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     'bind:checked': checkedSig,
     id,
@@ -19,7 +20,7 @@ export const Input = component$<InputProps>(
     const inputRef = useSignal<HTMLInputElement>();
 
     // TODO: remove this when we can figure out why the optimizer forces you to have a signal rather than conditionally adding the bind:value prop.
-    const dummySig = useSignal('');
+    const dummySig = useSignal<string | undefined>(value?.toString());
 
     return (
       <>


### PR DESCRIPTION
# What is it?

Workaround/Fix for #764

Workaround so the styled input is functional until `bind:value` prop can be conditional in Qwik core.

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
