### PR TITLE
remove | fix double dark:hover:bg-...  on MenuIcon (hamburger <svg>)

### DIFF
--- a/apps/website/src/components/icons/MenuIcon.tsx
+++ b/apps/website/src/components/icons/MenuIcon.tsx
@@ -4,7 +4,7 @@ export const MenuIcon = () => (
     fill="none"
     stroke-linecap="round"
     aria-hidden="true"
-    class="h-6 w-6 stroke-black hover:bg-gray-100 dark:stroke-white dark:hover:bg-slate-600"
+    class="h-6 w-6 stroke-black dark:stroke-white"
   >
     <path d="M.5 1h9M.5 8h9M.5 4.5h9" />
   </svg>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [x] Other

# Why is it needed?

fixes double background in dark mode ( ?could be fixed by using the same color as the button ?)
may not apply to all, but typically when I do svg components I just spread the props in there and make the default inherit ( which I think is a tailwind preflight)
# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [?] I have ran `pnpm change` and documented my changes
- [x] I have add necessary docs (if needed)
- [x] Added new tests to cover the fix / functionality
