### PR TITLE
fix: Only run single modal close step

### DIFF
--- a/.changeset/rich-windows-admire.md
+++ b/.changeset/rich-windows-admire.md
@@ -1,0 +1,5 @@
+---
+'@qwik-ui/headless': patch
+---
+
+fix: Only run single modal close step

--- a/packages/kit-headless/src/components/modal/use-modal.tsx
+++ b/packages/kit-headless/src/components/modal/use-modal.tsx
@@ -31,8 +31,7 @@ export function useModal() {
         },
         { once: true },
       );
-    }
-    if (transitionDuration !== '0s') {
+    } else if (transitionDuration !== '0s') {
       modal.addEventListener(
         'transitionend',
         (e) => {
@@ -45,8 +44,7 @@ export function useModal() {
         },
         { once: true },
       );
-    }
-    if (animationDuration === '0s' && transitionDuration === '0s') {
+    } else if (animationDuration === '0s' && transitionDuration === '0s') {
       delete modal.dataset.closing;
       modal.classList.remove('modal-closing');
       enableBodyScroll(modal);


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ X] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?
There was an issue where clicking onto the pane of the modal and pressing escape would cause future attempts at opening the modal to bug out.
<!-- Please link to an issue or describe why did you create this PR -->
[Bug Link](https://github.com/qwikifiers/qwik-ui/issues/817)

[After Fix](https://jam.dev/c/f098c32a-3a9c-4657-ad44-4737086898f0)

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
