### PR TITLE
fix: pass down select item indicator props

### DIFF
--- a/.changeset/little-llamas-brake.md
+++ b/.changeset/little-llamas-brake.md
@@ -1,0 +1,5 @@
+---
+'@qwik-ui/headless': patch
+---
+
+Enable select item indicator styling by passing down properties

--- a/packages/kit-headless/src/components/select/select-item-indicator.tsx
+++ b/packages/kit-headless/src/components/select/select-item-indicator.tsx
@@ -1,8 +1,8 @@
 import { PropsOf, Slot, component$, useContext } from '@builder.io/qwik';
 import { selectItemContextId } from './select-context';
 
-export const HSelectItemIndicator = component$<PropsOf<'span'>>(() => {
+export const HSelectItemIndicator = component$<PropsOf<'span'>>((props) => {
   const selectContext = useContext(selectItemContextId);
 
-  return <span>{selectContext.isSelectedSig.value && <Slot />}</span>;
+  return <span {...props}>{selectContext.isSelectedSig.value && <Slot />}</span>;
 });


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

In order to style the select item indicator, we need to pass the class property.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [x] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
