### PR TITLE
fix(styled-kit): add type keyword to imported types

### DIFF
--- a/apps/website/src/routes/docs/styled/accordion/index.mdx
+++ b/apps/website/src/routes/docs/styled/accordion/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add accordion
 ```
 
 ```tsx
-import { component$, Slot, PropsOf } from '@builder.io/qwik';
+import { component$, Slot, type PropsOf } from '@builder.io/qwik';
 
 import { Accordion as HeadlessAccordion } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';

--- a/apps/website/src/routes/docs/styled/alert/index.mdx
+++ b/apps/website/src/routes/docs/styled/alert/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add alert
 ```
 
 ```tsx
-import { component$, Slot, PropsOf } from '@builder.io/qwik';
+import { component$, Slot, type PropsOf } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/apps/website/src/routes/docs/styled/avatar/index.mdx
+++ b/apps/website/src/routes/docs/styled/avatar/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add avatar
 ```
 
 ```tsx
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 const Root = component$<PropsOf<'div'>>(({ ...props }) => {

--- a/apps/website/src/routes/docs/styled/badge/index.mdx
+++ b/apps/website/src/routes/docs/styled/badge/index.mdx
@@ -19,7 +19,7 @@ qwik-ui add badge
 ```
 
 ```tsx
-import { component$, PropsOf, Slot } from '@builder.io/qwik';
+import { component$, type PropsOf, Slot } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/apps/website/src/routes/docs/styled/breadcrumb/index.mdx
+++ b/apps/website/src/routes/docs/styled/breadcrumb/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add breadcrumb
 ```
 
 ```tsx
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 import { LuChevronRight } from '@qwikest/icons/lucide';
 

--- a/apps/website/src/routes/docs/styled/button/index.mdx
+++ b/apps/website/src/routes/docs/styled/button/index.mdx
@@ -11,7 +11,7 @@ qwik-ui add button
 ```
 
 ```tsx
-import { component$, PropsOf, Slot } from '@builder.io/qwik';
+import { component$, type PropsOf, Slot } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/apps/website/src/routes/docs/styled/checkbox/index.mdx
+++ b/apps/website/src/routes/docs/styled/checkbox/index.mdx
@@ -25,7 +25,7 @@ qwik-ui add checkbox
 ```
 
 ```tsx
-import { $, PropsOf, component$ } from '@builder.io/qwik';
+import { $, type PropsOf, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 export const Checkbox = component$<PropsOf<'input'>>(

--- a/apps/website/src/routes/docs/styled/combobox/index.mdx
+++ b/apps/website/src/routes/docs/styled/combobox/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add combobox
 ```
 
 ```tsx
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Combobox as HeadlessCombobox } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 import { LuChevronDown } from '@qwikest/icons/lucide';

--- a/apps/website/src/routes/docs/styled/label/index.mdx
+++ b/apps/website/src/routes/docs/styled/label/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add label
 ```
 
 ```tsx
-import { component$, Slot, PropsOf } from '@builder.io/qwik';
+import { component$, Slot, type PropsOf } from '@builder.io/qwik';
 import { Label as HeadlessLabel } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/apps/website/src/routes/docs/styled/modal/index.mdx
+++ b/apps/website/src/routes/docs/styled/modal/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add modal
 ```
 
 ```tsx
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Modal as HeadlessModal } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/apps/website/src/routes/docs/styled/popover/index.mdx
+++ b/apps/website/src/routes/docs/styled/popover/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add popover
 ```
 
 ```tsx
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Popover as HeadlessPopover } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/apps/website/src/routes/docs/styled/progress/index.mdx
+++ b/apps/website/src/routes/docs/styled/progress/index.mdx
@@ -22,7 +22,7 @@ qwik-ui add progress
 
 ```tsx
 import { cn } from '@qwik-ui/utils';
-import { PropsOf, component$ } from '@builder.io/qwik';
+import { type PropsOf, component$ } from '@builder.io/qwik';
 import { Progress as HeadlessProgress } from '@qwik-ui/headless';
 
 export const Progress = component$<PropsOf<typeof HeadlessProgress.Root>>((props) => {

--- a/apps/website/src/routes/docs/styled/radio-group/index.mdx
+++ b/apps/website/src/routes/docs/styled/radio-group/index.mdx
@@ -25,7 +25,7 @@ qwik-ui add radio-group
 ```
 
 ```tsx
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 const Root = component$<PropsOf<'div'>>(({ ...props }) => {

--- a/apps/website/src/routes/docs/styled/select/index.mdx
+++ b/apps/website/src/routes/docs/styled/select/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add select
 ```
 
 ```tsx
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Select as HeadlessSelect } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 import { LuCheck, LuChevronDown } from '@qwikest/icons/lucide';

--- a/apps/website/src/routes/docs/styled/separator/index.mdx
+++ b/apps/website/src/routes/docs/styled/separator/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add separator
 ```
 
 ```tsx
-import { PropsOf, component$ } from '@builder.io/qwik';
+import { type PropsOf, component$ } from '@builder.io/qwik';
 import { Separator as HeadlessSeparator } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/apps/website/src/routes/docs/styled/skeleton/index.mdx
+++ b/apps/website/src/routes/docs/styled/skeleton/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add skeleton
 ```
 
 ```tsx
-import { PropsOf, component$ } from '@builder.io/qwik';
+import { type PropsOf, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 export const Skeleton = component$<PropsOf<'div'>>(({ ...props }) => {

--- a/apps/website/src/routes/docs/styled/tabs/index.mdx
+++ b/apps/website/src/routes/docs/styled/tabs/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add tabs
 ```
 
 ```tsx
-import { Slot, component$, PropsOf } from '@builder.io/qwik';
+import { Slot, component$, type PropsOf } from '@builder.io/qwik';
 import { Tabs as HeadlessTabs } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/apps/website/src/routes/docs/styled/textarea/index.mdx
+++ b/apps/website/src/routes/docs/styled/textarea/index.mdx
@@ -21,7 +21,7 @@ qwik-ui add textarea
 ```
 
 ```tsx
-import { $, component$, PropsOf } from '@builder.io/qwik';
+import { $, component$, type PropsOf } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 type TextareaProps = PropsOf<'textarea'> & {

--- a/packages/kit-styled/src/components/accordion/accordion.tsx
+++ b/packages/kit-styled/src/components/accordion/accordion.tsx
@@ -1,4 +1,4 @@
-import { component$, Slot, PropsOf } from '@builder.io/qwik';
+import { component$, Slot, type PropsOf } from '@builder.io/qwik';
 
 import { Accordion as HeadlessAccordion } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';

--- a/packages/kit-styled/src/components/alert/alert.tsx
+++ b/packages/kit-styled/src/components/alert/alert.tsx
@@ -1,4 +1,4 @@
-import { component$, Slot, PropsOf } from '@builder.io/qwik';
+import { component$, Slot, type PropsOf } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/packages/kit-styled/src/components/avatar/avatar.tsx
+++ b/packages/kit-styled/src/components/avatar/avatar.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 const Root = component$<PropsOf<'div'>>(({ ...props }) => {

--- a/packages/kit-styled/src/components/badge/badge.tsx
+++ b/packages/kit-styled/src/components/badge/badge.tsx
@@ -1,4 +1,4 @@
-import { component$, PropsOf, Slot } from '@builder.io/qwik';
+import { component$, type PropsOf, Slot } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/packages/kit-styled/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/kit-styled/src/components/breadcrumb/breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 import { LuChevronRight } from '@qwikest/icons/lucide';
 

--- a/packages/kit-styled/src/components/button/button.tsx
+++ b/packages/kit-styled/src/components/button/button.tsx
@@ -1,4 +1,4 @@
-import { component$, PropsOf, Slot } from '@builder.io/qwik';
+import { component$, type PropsOf, Slot } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/packages/kit-styled/src/components/checkbox/checkbox.tsx
+++ b/packages/kit-styled/src/components/checkbox/checkbox.tsx
@@ -1,4 +1,4 @@
-import { $, PropsOf, component$ } from '@builder.io/qwik';
+import { $, type PropsOf, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 export const Checkbox = component$<PropsOf<'input'> & { type?: 'checkbox' }>(

--- a/packages/kit-styled/src/components/combobox/combobox.tsx
+++ b/packages/kit-styled/src/components/combobox/combobox.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Combobox as HeadlessCombobox } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 import { LuChevronDown } from '@qwikest/icons/lucide';

--- a/packages/kit-styled/src/components/label/label.tsx
+++ b/packages/kit-styled/src/components/label/label.tsx
@@ -1,4 +1,4 @@
-import { component$, Slot, PropsOf } from '@builder.io/qwik';
+import { component$, Slot, type PropsOf } from '@builder.io/qwik';
 import { Label as HeadlessLabel } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/packages/kit-styled/src/components/modal/modal.tsx
+++ b/packages/kit-styled/src/components/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Modal as HeadlessModal } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/packages/kit-styled/src/components/popover/popover.tsx
+++ b/packages/kit-styled/src/components/popover/popover.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Popover as HeadlessPopover } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/packages/kit-styled/src/components/progress/progress.tsx
+++ b/packages/kit-styled/src/components/progress/progress.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@qwik-ui/utils';
-import { PropsOf, component$ } from '@builder.io/qwik';
+import { type PropsOf, component$ } from '@builder.io/qwik';
 import { Progress as HeadlessProgress } from '@qwik-ui/headless';
 
 export const Progress = component$<PropsOf<typeof HeadlessProgress.Root>>((props) => {

--- a/packages/kit-styled/src/components/radio-group/radio-group.tsx
+++ b/packages/kit-styled/src/components/radio-group/radio-group.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 const Root = component$<PropsOf<'div'>>(({ ...props }) => {

--- a/packages/kit-styled/src/components/select/select.tsx
+++ b/packages/kit-styled/src/components/select/select.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, Slot, component$ } from '@builder.io/qwik';
+import { type PropsOf, Slot, component$ } from '@builder.io/qwik';
 import { Select as HeadlessSelect } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 import { LuCheck, LuChevronDown } from '@qwikest/icons/lucide';

--- a/packages/kit-styled/src/components/separator/separator.tsx
+++ b/packages/kit-styled/src/components/separator/separator.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, component$ } from '@builder.io/qwik';
+import { type PropsOf, component$ } from '@builder.io/qwik';
 import { Separator as HeadlessSeparator } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/packages/kit-styled/src/components/skeleton/skeleton.tsx
+++ b/packages/kit-styled/src/components/skeleton/skeleton.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, component$ } from '@builder.io/qwik';
+import { type PropsOf, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 export const Skeleton = component$<PropsOf<'div'>>(({ ...props }) => {

--- a/packages/kit-styled/src/components/tabs/tabs.tsx
+++ b/packages/kit-styled/src/components/tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import { Slot, component$, PropsOf } from '@builder.io/qwik';
+import { Slot, component$, type PropsOf } from '@builder.io/qwik';
 import { Tabs as HeadlessTabs } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 

--- a/packages/kit-styled/src/components/textarea/textarea.tsx
+++ b/packages/kit-styled/src/components/textarea/textarea.tsx
@@ -1,4 +1,4 @@
-import { $, component$, PropsOf } from '@builder.io/qwik';
+import { $, component$, type PropsOf } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 type TextareaProps = PropsOf<'textarea'> & {

--- a/packages/kit-styled/src/components/toggle/toggle.tsx
+++ b/packages/kit-styled/src/components/toggle/toggle.tsx
@@ -1,4 +1,4 @@
-import { PropsOf, component$ } from '@builder.io/qwik';
+import { type PropsOf, component$ } from '@builder.io/qwik';
 import { Toggle as HeadlessToggle } from '@qwik-ui/headless';
 import { cn } from '@qwik-ui/utils';
 import { VariantProps, cva } from 'class-variance-authority';


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [x] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->
**NOTE**: THIS IS FOR STYLED KIT
I was trying to copy/paste the textarea component in the styled kit in Qwik UI and I get this error:
```PropsOf' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.ts(1484)```

I was hesitating to do this PR because, in this code base I didn't get the error. (I think something in the ts config and I'm eager to know it). But the Card and Input components have the `type` keywords and others do not.
So it should be either in all or in none. What do you think?

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
