### PR TITLE
fix(landing): correct image alt

### DIFF
--- a/apps/website/src/routes/index@landing.tsx
+++ b/apps/website/src/routes/index@landing.tsx
@@ -63,7 +63,7 @@ export default component$(() => {
               src={`/images/qwik-ui-headless-hero.webp`}
               width="300"
               height="300"
-              alt={`styled kit`}
+              alt={`headless kit`}
               class="w-full rounded-t-sm"
             />
             <Card.Header>


### PR DESCRIPTION
# What is it?

Today, the headless kit's image alt is `styled kit`, this PR corrects it to `headless kit`.

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [x] Other

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
