### PR TITLE
fix: breadcrumb class override instead of concatenate

### DIFF
--- a/apps/website/src/routes/docs/styled/breadcrumb/index.mdx
+++ b/apps/website/src/routes/docs/styled/breadcrumb/index.mdx
@@ -37,11 +37,11 @@ const Root = component$<BreadcrumbProps>(() => {
 const List = component$<PropsOf<'ol'>>((props) => {
   return (
     <ol
+      {...props}
       class={cn(
         ' flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5',
         props.class,
       )}
-      {...props}
     >
       <Slot />
     </ol>
@@ -50,7 +50,7 @@ const List = component$<PropsOf<'ol'>>((props) => {
 
 const Item = component$<PropsOf<'li'>>((props) => {
   return (
-    <li class={cn('inline-flex items-center gap-1.5', props.class)} {...props}>
+    <li {...props} class={cn('inline-flex items-center gap-1.5', props.class)}>
       <Slot />
     </li>
   );
@@ -60,11 +60,11 @@ const Link = component$<PropsOf<'a'> & { asChild?: boolean }>((props) => {
   const Comp = props.asChild ? Slot : 'a';
   return (
     <Comp
+      {...props}
       class={cn(
         'text-muted-foreground transition-colors hover:text-foreground',
         props.class,
       )}
-      {...props}
     >
       {!props.asChild && <Slot />}
     </Comp>
@@ -85,8 +85,8 @@ const Page = component$<PropsOf<'span'>>((props) => {
       role="link"
       aria-disabled="true"
       aria-current="page"
-      class={cn('font-normal text-foreground', props.class)}
       {...props}
+      class={cn('font-normal text-foreground', props.class)}
     >
       <Slot />
     </span>

--- a/packages/kit-styled/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/kit-styled/src/components/breadcrumb/breadcrumb.tsx
@@ -14,11 +14,11 @@ const Root = component$<BreadcrumbProps>(() => {
 const List = component$<PropsOf<'ol'>>((props) => {
   return (
     <ol
+      {...props}
       class={cn(
         ' flex flex-wrap items-center gap-1.5 break-words text-sm sm:gap-2.5',
         props.class,
       )}
-      {...props}
     >
       <Slot />
     </ol>
@@ -27,7 +27,7 @@ const List = component$<PropsOf<'ol'>>((props) => {
 
 const Item = component$<PropsOf<'li'>>((props) => {
   return (
-    <li class={cn('inline-flex items-center gap-1.5', props.class)} {...props}>
+    <li {...props} class={cn('inline-flex items-center gap-1.5', props.class)}>
       <Slot />
     </li>
   );
@@ -37,11 +37,11 @@ const Link = component$<PropsOf<'a'> & { asChild?: boolean }>((props) => {
   const Comp = props.asChild ? Slot : 'a';
   return (
     <Comp
+      {...props}
       class={cn(
         'text-muted-foreground transition-colors hover:text-foreground',
         props.class,
       )}
-      {...props}
     >
       {!props.asChild && <Slot />}
     </Comp>
@@ -62,8 +62,8 @@ const Page = component$<PropsOf<'span'>>((props) => {
       role="link"
       aria-disabled="true"
       aria-current="page"
-      class={cn('font-normal text-foreground', props.class)}
       {...props}
+      class={cn('font-normal text-foreground', props.class)}
     >
       <Slot />
     </span>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->
Because we spread props after the class attribute, It gets overridden instead of concatenated with the `cn` function.
I have checked other components and it seems this problem is only in the Breadcrumb component.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes (I don't konw if this should be patched or not !!)
- [x] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
