### PR TITLE
Updated popover docs to show onToggle

### DIFF
--- a/apps/website/src/routes/docs/headless/popover/examples/toggle-event.tsx
+++ b/apps/website/src/routes/docs/headless/popover/examples/toggle-event.tsx
@@ -1,0 +1,20 @@
+import { component$, useSignal } from '@builder.io/qwik';
+import { Popover } from '@qwik-ui/headless';
+export default component$(() => {
+  const toggleStatus = useSignal<'open' | 'closed'>('closed');
+
+  return (
+    <Popover.Root>
+      <p>Panel is {toggleStatus.value}!</p>
+      <Popover.Trigger class="popover-trigger">Popover Trigger</Popover.Trigger>
+      <Popover.Panel
+        class="popover-panel"
+        onToggle$={(e) => {
+          toggleStatus.value = e.newState;
+        }}
+      >
+        My Hero!
+      </Popover.Panel>
+    </Popover.Root>
+  );
+});

--- a/apps/website/src/routes/docs/headless/popover/index.mdx
+++ b/apps/website/src/routes/docs/headless/popover/index.mdx
@@ -243,6 +243,14 @@ Above is an example of how we programmatically open and close the popover in the
 
 > In the native spec, these are methods, although we want to ensure code executes on interaction in all browsers, including the polyfill.
 
+### Handling state changes
+
+<Showcase name="toggle-event" />
+
+Use the `onToggle$` prop on the `<Popover.Panel>` to listen for changes to the popover visibility.
+
+The example above uses a `Signal` to track whether the popover is triggered or not.
+
 ## Floating Behavior
 
 By default, the Qwik UI Popover will float below the trigger component.
@@ -474,6 +482,19 @@ To read more about the popover API you can check it out on:
       name: 'data-closing',
       type: 'class',
       description: 'Class to animate exit behavior.',
+    },
+  ]}
+/>
+
+### Popover Panel
+
+<APITable
+  propDescriptors={[
+    {
+      name: 'onToggle',
+      type: 'QRL',
+      description: 'Function called when the popover opens or closes',
+      info: 'QRL<(event: CorrectedToggleEvent, element: HTMLDivElement) => void>',
     },
   ]}
 />


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests
- [ ] Other

# Why is it needed?

Documented existing `onChange$` functionality on the `<Popover.Panel>` component that allows a user to track the current state of the popover.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [x] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
