### PR TITLE
single shiki instance & on the server w/ dev

### DIFF
--- a/apps/website/src/components/highlight/highlight.tsx
+++ b/apps/website/src/components/highlight/highlight.tsx
@@ -1,25 +1,23 @@
-import {
-  ClassList,
-  PropsOf,
-  component$,
-  useSignal,
-  useTask$,
-  useVisibleTask$,
-  $,
-} from '@builder.io/qwik';
+import { ClassList, PropsOf, component$, useSignal, useTask$ } from '@builder.io/qwik';
 import { CodeCopy } from '../code-copy/code-copy';
 import { cn } from '@qwik-ui/utils';
-import { isDev } from '@builder.io/qwik/build';
 import poimandres from 'shiki/themes/poimandres.mjs';
 import html from 'shiki/langs/html.mjs';
 import css from 'shiki/langs/css.mjs';
 import tsx from 'shiki/langs/tsx.mjs';
-import { createHighlighterCore } from 'shiki/index.mjs';
+import { createHighlighterCore, BundledLanguage } from 'shiki/index.mjs';
+
+// Create a single highlighter instance
+const highlighterPromise = createHighlighterCore({
+  themes: [poimandres],
+  langs: [html, css, tsx],
+  loadWasm: import('shiki/wasm'),
+});
 
 export type HighlightProps = PropsOf<'div'> & {
   code: string;
   copyCodeClass?: ClassList;
-  language?: 'tsx' | 'html' | 'css';
+  language?: BundledLanguage;
   splitCommentStart?: string;
   splitCommentEnd?: string;
 };
@@ -35,7 +33,7 @@ export const Highlight = component$(
   }: HighlightProps) => {
     const codeSig = useSignal('');
 
-    const addShiki$ = $(async () => {
+    useTask$(async function initShiki() {
       let modifiedCode: string = code;
 
       let partsOfCode = modifiedCode.split(splitCommentStart);
@@ -48,35 +46,12 @@ export const Highlight = component$(
         modifiedCode = partsOfCode[0];
       }
 
-      const highlighter = await createHighlighterCore({
-        themes: [poimandres],
-        langs: [html, css, tsx],
-        loadWasm: import('shiki/wasm'),
-      });
-
+      const highlighter = await highlighterPromise;
       const str = highlighter.codeToHtml(modifiedCode, {
         lang: language,
-        themes: {
-          light: 'poimandres',
-          dark: 'poimandres',
-        },
+        theme: 'poimandres',
       });
-      codeSig.value = str.toString();
-    });
-
-    useTask$(async ({ track }) => {
-      track(() => code);
-      if (!isDev) {
-        await addShiki$();
-      }
-    });
-
-    // eslint-disable-next-line qwik/no-use-visible-task
-    useVisibleTask$(async ({ track }) => {
-      track(() => code);
-      if (isDev) {
-        await addShiki$();
-      }
+      codeSig.value = str;
     });
 
     return (

--- a/apps/website/src/components/highlight/highlight.tsx
+++ b/apps/website/src/components/highlight/highlight.tsx
@@ -33,7 +33,8 @@ export const Highlight = component$(
   }: HighlightProps) => {
     const codeSig = useSignal('');
 
-    useTask$(async function initShiki() {
+    useTask$(async ({ track }) => {
+      track(() => code);
       let modifiedCode: string = code;
 
       let partsOfCode = modifiedCode.split(splitCommentStart);


### PR DESCRIPTION
# What is it?

Preview route transitions are now much faster, shiki should now be working correctly in dev mode and preview, as I believe the previous error was due to multiple instances being created each time an example was rendered.

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
