### PR TITLE
chore(website): disable qwikVite linter to speed up preview and builds

### DIFF
--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -76,6 +76,7 @@ export default defineConfig(async () => {
         },
       }),
       qwikVite({
+        lint: false,
         tsconfigFileNames: ['tsconfig.app.json'],
         client: {
           outDir: '../../dist/apps/website/client',


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [x] Other

# Why is it needed?

Eslint working in VSCode should be enough.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
