### PR TITLE
fix: useComputed$ double read

### DIFF
--- a/apps/website/src/routes/docs/headless/combobox/auto-api/api.ts
+++ b/apps/website/src/routes/docs/headless/combobox/auto-api/api.ts
@@ -45,17 +45,17 @@ export const api = {
           HComboboxItemProps: [
             {
               comment:
-                ' Internal index we get from the inline component. Please see combobox-inline.tsx ',
+                'Internal index we get from the inline component. Please see combobox-inline.tsx',
               prop: '_index',
               type: 'number',
             },
             {
-              comment: ' If true, item is not selectable or focusable. ',
+              comment: 'If true, item is not selectable or focusable.',
               prop: 'disabled',
               type: 'boolean',
             },
             {
-              comment: ' Selected value associated with the item. ',
+              comment: 'Selected value associated with the item.',
               prop: 'value',
               type: 'string',
             },

--- a/apps/website/src/routes/docs/headless/dropdown/auto-api/api.ts
+++ b/apps/website/src/routes/docs/headless/dropdown/auto-api/api.ts
@@ -5,13 +5,12 @@ export const api = {
         {
           DropdownCheckboxItemProps: [
             {
-              comment:
-                '\n    A signal that controls the current checked value (controlled).\n   ',
+              comment: 'A signal that controls the current checked value (controlled).',
               prop: "'bind:checked'",
               type: 'Signal<boolean>',
             },
             {
-              comment: '\n    QRL handler that runs when the checked value changes.\n   ',
+              comment: 'QRL handler that runs when the checked value changes.',
               prop: 'onChange$',
               type: 'QRL<(checked: boolean) => void>',
             },
@@ -40,22 +39,22 @@ export const api = {
           DropdownItemProps: [
             {
               comment:
-                ' Internal index we get from the inline component. Please see dropdown-inline.tsx ',
+                'Internal index we get from the inline component. Please see dropdown-inline.tsx',
               prop: '_index',
               type: 'number',
             },
             {
-              comment: ' If true, item is not selectable or focusable. ',
+              comment: 'If true, item is not selectable or focusable.',
               prop: 'disabled',
               type: 'boolean',
             },
             {
-              comment: ' If true, dropdown will close after selecting the item. ',
+              comment: 'If true, dropdown will close after selecting the item.',
               prop: 'closeOnSelect',
               type: 'boolean',
             },
             {
-              comment: '\n    QRL handler that runs when the user selects an item.\n   ',
+              comment: 'QRL handler that runs when the user selects an item.',
               prop: 'onClick$',
               type: 'QRL<() => void>',
             },
@@ -77,25 +76,25 @@ export const api = {
         {
           DropdownProps: [
             {
-              comment: ' A signal that controls the current open state (controlled). ',
+              comment: 'A signal that controls the current open state (controlled).',
               prop: "'bind:open'",
               type: 'Signal<boolean>',
             },
             {
               comment:
-                '\n    QRL handler that runs when the dropdown opens or closes.\n    @param open The new state of the dropdown.\n   \n   ',
+                'QRL handler that runs when the dropdown opens or closes.\n    @param open The new state of the dropdown.',
               prop: 'onOpenChange$',
               type: 'QRL<(open: boolean) => void>',
             },
             {
               comment:
-                '\n     The native scrollIntoView method is used to scroll the options into view when the user highlights an option. This allows customization of the scroll behavior.\n   ',
+                'The native scrollIntoView method is used to scroll the options into view when the user highlights an option. This allows customization of the scroll behavior.',
               prop: 'scrollOptions',
               type: 'ScrollIntoViewOptions',
             },
             {
               comment:
-                '\n     Enables looped behavior when the user navigates through the options using the arrow keys.\n   ',
+                'Enables looped behavior when the user navigates through the options using the arrow keys.',
               prop: 'loop',
               type: 'boolean',
             },

--- a/packages/kit-headless/src/components/combobox/combobox-input.tsx
+++ b/packages/kit-headless/src/components/combobox/combobox-input.tsx
@@ -28,28 +28,32 @@ export const HComboboxInput = component$(
     const initialValueSig = useSignal<string | string[] | undefined>();
     const wasEmptyBeforeBackspaceSig = useSignal(false);
     const isInputResetSig = useSignal(false);
+    const activeDescendantSig = useSignal<string | undefined>(undefined);
 
     const { selectionManager$, getNextEnabledItemIndex$, getPrevEnabledItemIndex$ } =
       useCombobox();
 
-    const activeDescendantSig = useComputed$(() => {
-      if (!context.isListboxOpenSig.value) {
-        return '';
-      }
+    useTask$(function getActiveDescendant({ track }) {
+      track(() => context.highlightedIndexSig.value);
+      track(() => context.isListboxOpenSig.value);
 
       const highlightedIndex = context.highlightedIndexSig.value ?? -1;
       const highlightedItem = context.itemsMapSig.value.get(highlightedIndex);
+
+      if (!context.isListboxOpenSig.value) {
+        activeDescendantSig.value = '';
+        return;
+      }
 
       if (
         highlightedIndex === null ||
         highlightedIndex === -1 ||
         highlightedItem?.disabled
       ) {
-        return '';
+        return;
       }
 
-      // highlighted item id
-      return `${context.localId}-${highlightedIndex}`;
+      activeDescendantSig.value = `${context.localId}-${highlightedIndex}`;
     });
 
     const handleKeyDownSync$ = sync$((e: KeyboardEvent) => {

--- a/packages/kit-headless/src/components/dropdown/dropdown-root.tsx
+++ b/packages/kit-headless/src/components/dropdown/dropdown-root.tsx
@@ -84,6 +84,7 @@ export const HDropdownImpl = component$<DropdownProps & InternalDropdownProps>(
     const initialLoadSig = useSignal<boolean>(true);
     const highlightedItemRef = useSignal<HTMLLIElement>();
     const isMouseOverPopupSig = useSignal<boolean>(false);
+    const activeDescendantSig = useSignal<string | undefined>(undefined);
 
     const context: DropdownContext = {
       itemsMapSig,
@@ -117,25 +118,27 @@ export const HDropdownImpl = component$<DropdownProps & InternalDropdownProps>(
       }
     });
 
-    // only evaluate when open
-    const activeDescendantSig = useComputed$(() => {
-      if (!isOpenSig.value) {
-        return '';
-      }
+    useTask$(function getActiveDescendant({ track }) {
+      track(() => highlightedIndexSig.value);
+      track(() => isOpenSig.value);
 
       const highlightedIndex = context.highlightedIndexSig.value ?? -1;
       const highlightedItem = context.itemsMapSig.value.get(highlightedIndex);
+
+      if (!isOpenSig.value) {
+        activeDescendantSig.value = '';
+        return;
+      }
 
       if (
         highlightedIndex === null ||
         highlightedIndex === -1 ||
         highlightedItem?.disabled
       ) {
-        return '';
+        return;
       }
 
-      // highlighted item id
-      return `${context.localId}-${highlightedIndex}`;
+      activeDescendantSig.value = `${context.localId}-${highlightedIndex}`;
     });
 
     useTask$(() => {


### PR DESCRIPTION
In v2 combobox and dropdown break because of a computed that does a signal read of another computed.

This works as a workaround (but is also more efficient) to the bug in v2.

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
