### PR TITLE
fix(auto api): query too strict

### DIFF
--- a/apps/website/auto-api.ts
+++ b/apps/website/auto-api.ts
@@ -16,8 +16,7 @@ const parser = new Parser();
 
 const query = new Query(
   TS.tsx,
-  `declaration: 
-    (type_alias_declaration
+  `(type_alias_declaration
       name: (type_identifier) @subComponentName
       (intersection_type
         (object_type


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests
- [ ] Other

# Why is it needed?

TLDR: current query only works if you are exporting the type because its too strict, so this fixes that.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [x] I have add necessary docs (if needed)
- [x] Added new tests to cover the fix / functionality
