### PR TITLE
added redirect to repro stackblitz

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -35,7 +35,7 @@ body:
     id: reproduction
     attributes:
       label: Reproduction
-      description: Please provide a link via [qwik.new](https://qwik.new/) or a link to a repo that can reproduce the problem you ran into. `npm create qwik@latest` can be used as a starter template. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required ([Why?](https://antfu.me/posts/why-reproductions-are-required)). If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided after 14 days, it will be auto-closed.
+      description: Please provide a link via [https://qwikui.com/repro](https://qwikui.com/repro) or clone [this repo](https://github.com/qwikifiers/qwik-ui-stackblitz) and reproduce the problem you ran into. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required ([Why?](https://antfu.me/posts/why-reproductions-are-required)). If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided after 14 days, it will be auto-closed.
       placeholder: Reproduction URL
     validations:
       required: true

--- a/apps/website/public/_redirects
+++ b/apps/website/public/_redirects
@@ -1,1 +1,4 @@
 # https://developers.cloudflare.com/pages/platform/redirects/
+
+/repro https://stackblitz.com/~/github.com/qwikifiers/qwik-ui-stackblitz 307
+/repro/ https://stackblitz.com/~/github.com/qwikifiers/qwik-ui-stackblitz 307


### PR DESCRIPTION
# What is it?

Now qwik-ui users can create a fast reproduction for bugs using our new stackblitz starter.

**Link to reproduction stackblitz:**

https://qwikui.com/repro

**Github repository:**
https://github.com/qwikifiers/qwik-ui-stackblitz

All qwik-ui maintainers have write permission to this repo so it could be maintained when we add new components . 