### PR TITLE
fix: recursive alias imports

### DIFF
--- a/packages/kit-headless/src/components/accordion/accordion-inline.tsx
+++ b/packages/kit-headless/src/components/accordion/accordion-inline.tsx
@@ -1,10 +1,10 @@
 import { Component } from '@builder.io/qwik';
 import { type AccordionRootProps, HAccordionRootImpl } from './accordion-root';
-import { Accordion } from '@qwik-ui/headless';
 import { findComponent, processChildren } from '../../utils/inline-component';
+import { HAccordionItem } from './accordion-item';
 
 type InternalProps = {
-  accordionItemComponent?: typeof Accordion.Item;
+  accordionItemComponent?: typeof HAccordionItem;
 };
 
 export const HAccordionRoot: Component<AccordionRootProps & InternalProps> = (
@@ -16,7 +16,7 @@ export const HAccordionRoot: Component<AccordionRootProps & InternalProps> = (
     value: initialValue,
     ...rest
   } = props;
-  const Item = GivenItem || Accordion.Item;
+  const Item = GivenItem || HAccordionItem;
   let currItemIndex = 0;
   let initialIndex = null;
   const itemsMap = new Map();

--- a/packages/kit-headless/src/components/carousel/inline.tsx
+++ b/packages/kit-headless/src/components/carousel/inline.tsx
@@ -1,23 +1,26 @@
 import { Component } from '@builder.io/qwik';
 import { CarouselBase, PublicCarouselRootProps } from './root';
-import { Carousel } from '@qwik-ui/headless';
 import { findComponent, processChildren } from '../../utils/inline-component';
+import { CarouselSlide } from './slide';
+import { CarouselBullet } from './bullet';
+import { CarouselStep } from './step';
+import { CarouselTitle } from './title';
 
 type InternalProps = {
   value?: string;
   /**
    * @deprecated Use `slideComponent` instead.
    */
-  carouselSlideComponent?: typeof Carousel.Slide;
+  carouselSlideComponent?: typeof CarouselSlide;
   /**
    * @deprecated Use `bulletComponent` instead.
    */
-  carouselBulletComponent?: typeof Carousel.Bullet;
+  carouselBulletComponent?: typeof CarouselBullet;
 
-  slideComponent?: typeof Carousel.Slide;
-  bulletComponent?: typeof Carousel.Bullet;
-  stepComponent?: typeof Carousel.Step;
-  titleComponent?: typeof Carousel.Title;
+  slideComponent?: typeof CarouselSlide;
+  bulletComponent?: typeof CarouselBullet;
+  stepComponent?: typeof CarouselStep;
+  titleComponent?: typeof CarouselTitle;
 };
 
 export const CarouselRoot: Component<PublicCarouselRootProps & InternalProps> = (
@@ -33,10 +36,10 @@ export const CarouselRoot: Component<PublicCarouselRootProps & InternalProps> = 
     titleComponent: GivenTitle,
     ...rest
   } = props;
-  const Slide = GivenSlide || GivenSlideOld || Carousel.Slide;
-  const Bullet = GivenBullet || GivenBulletOld || Carousel.Bullet;
-  const Step = GivenStep || Carousel.Step;
-  const Title = GivenTitle || Carousel.Title;
+  const Slide = GivenSlide || GivenSlideOld || CarouselSlide;
+  const Bullet = GivenBullet || GivenBulletOld || CarouselBullet;
+  const Step = GivenStep || CarouselStep;
+  const Title = GivenTitle || CarouselTitle;
   let currSlideIndex = 0;
   let currBulletIndex = 0;
   let currStepIndex = 0;

--- a/packages/kit-headless/src/components/toggle-group/toggle-group-item.tsx
+++ b/packages/kit-headless/src/components/toggle-group/toggle-group-item.tsx
@@ -8,7 +8,8 @@ import {
   useSignal,
   useTask$,
 } from '@builder.io/qwik';
-import { Toggle } from '@qwik-ui/headless';
+import { isBrowser, isServer } from '@builder.io/qwik/build';
+
 import {
   Direction,
   Item,
@@ -16,7 +17,7 @@ import {
   toggleGroupRootApiContextId,
 } from './toggle-group-context';
 import { KeyCode } from '../../utils';
-import { isBrowser, isServer } from '@builder.io/qwik/build';
+import { Toggle } from '../toggle';
 
 type NavigationKeys =
   | KeyCode.ArrowRight

--- a/packages/kit-styled/src/components/toggle-group/toggle-group.tsx
+++ b/packages/kit-styled/src/components/toggle-group/toggle-group.tsx
@@ -8,10 +8,10 @@ import {
 import { cn } from '@qwik-ui/utils';
 import { ToggleGroup as HeadlessToggleGroup } from '@qwik-ui/headless';
 
-import { toggleVariants } from '@qwik-ui/styled';
 import type { VariantProps } from 'class-variance-authority';
 
 import { createContextId } from '@builder.io/qwik';
+import { toggleVariants } from '../toggle/toggle';
 
 export const toggleGroupStyledContextId = createContextId<ToggleGroupStyledContext>(
   'qui-toggle-group-styled',


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

cc @thejackshelton we need to avoid importing from e.g. @qwik-ui/headless inside the headless package itself, otherwise the optimizer adds unrelated imports to a component when building the lib, which leads to over-prefetching to consumers of that lib.

![image](https://github.com/user-attachments/assets/b3cc6131-6c1a-434c-b050-6e51149ed148)
Here the toggle-group-item imports a lot of components from Accordion and Dropdown (because it's an MRE and there's only Accordion, Dropdown, Toggle and ToggleGroup). This will lead to over-prefetching.

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
