### PR TITLE
docs(styled): add '@qwik-ui/utils' and 'class-variance-authority' to …

### DIFF
--- a/apps/website/src/routes/docs/styled/(getting-started)/install/index.mdx
+++ b/apps/website/src/routes/docs/styled/(getting-started)/install/index.mdx
@@ -35,7 +35,7 @@ pnpm qwik-ui add input
 ### Step 1: Install the Headless Kit and qwikest icons
 
 ```zsh
-pnpm i -D @qwik-ui/headless @qwikest/icons tailwindcss-animate
+pnpm i -D @qwik-ui/headless @qwikest/icons tailwindcss-animate @qwik-ui/utils class-variance-authority
 ```
 
 ### Step 2: copy/paste your theme config


### PR DESCRIPTION
…manual install guide

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests
- [ ] Other

# Why is it needed?
I used the manual installation guide, And after I copy past the `button` components and I found that am missing these packages `class-variance-authority` and `@qwik-ui/utils`.
Also it used in multiple components like `badge` and `label` .....
<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
