### PR TITLE
fix(styled kit): allow consumer to pass onInput$ with two way data-binding & fix forms

### DIFF
--- a/.changeset/sour-walls-lay.md
+++ b/.changeset/sour-walls-lay.md
@@ -1,0 +1,5 @@
+---
+'@qwik-ui/styled': patch
+---
+
+PATCH: The styled Input, Checkbox and Textarea components now properly handle two way data-binding and allow passing onInput$ outside and inside of forms.

--- a/apps/website/src/routes/docs/styled/checkbox/index.mdx
+++ b/apps/website/src/routes/docs/styled/checkbox/index.mdx
@@ -30,22 +30,23 @@ qwik-ui add checkbox
 import { $, type PropsOf, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
-export const Checkbox = component$<PropsOf<'input'>>(
-  ({ id, name, ['bind:checked']: checkedSig, checked, onInput$, ...props }) => {
+export const Checkbox = component$<Partial<PropsOf<'input'> & { type?: 'checkbox' }>>(
+  ({ id, name, ['bind:checked']: bindSig, checked, onInput$, ...props }) => {
     const inputId = id || name;
     return (
       <input
-        type="checkbox"
         {...props}
+        type="checkbox"
         // workaround to support two way data-binding on the Input component (https://github.com/QwikDev/qwik/issues/3926)
-        checked={checkedSig ? checkedSig.value : checked}
-        onInput$={checkedSig ? $((_, el) => (checkedSig.value = el.checked)) : onInput$}
-        data-checked={checked || checkedSig?.value || ''}
+        checked={bindSig ? bindSig.value : checked}
+        onInput$={[bindSig && $((_, el) => (bindSig.value = el.checked)), onInput$]}
+        data-checked={checked || bindSig?.value || ''}
         class={cn(
           'peer h-4 w-4 shrink-0 border-primary text-primary accent-primary ring-offset-background focus:ring-ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
           props.class,
         )}
         id={inputId}
+        name={name}
       />
     );
   },

--- a/apps/website/src/routes/docs/styled/input/index.mdx
+++ b/apps/website/src/routes/docs/styled/input/index.mdx
@@ -31,7 +31,7 @@ type InputProps = PropsOf<'input'> & {
 };
 
 export const Input = component$<InputProps>(
-  ({ name, error, id, ['bind:value']: valueSig, value, onInput$, ...props }) => {
+  ({ name, error, id, ['bind:value']: bindSig, value, onInput$, ...props }) => {
     const inputId = id || name;
 
     return (
@@ -39,18 +39,19 @@ export const Input = component$<InputProps>(
         <input
           {...props}
           aria-errormessage={`${inputId}-error`}
-          aria-invaid={!!error}
+          aria-invalid={!!error}
           // workaround to support two way data-binding on the Input component (https://github.com/QwikDev/qwik/issues/3926)
-          value={valueSig ? valueSig.value : value}
-          onInput$={valueSig ? $((__, el) => (valueSig.value = el.value)) : onInput$}
+          value={bindSig ? bindSig.value : value}
+          onInput$={[bindSig && $((_, el) => (bindSig.value = el.value)), onInput$]}
           class={cn(
             'flex h-12 w-full rounded-base border border-input bg-background px-3 py-1 text-sm text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
             props.class,
           )}
           id={inputId}
+          name={name}
         />
         {error && (
-          <div id={`${inputId}-error`} class="text-alert mt-1 text-sm">
+          <div id={`${inputId}-error`} class="mt-1 text-sm text-alert">
             {error}
           </div>
         )}

--- a/apps/website/src/routes/docs/styled/textarea/index.mdx
+++ b/apps/website/src/routes/docs/styled/textarea/index.mdx
@@ -31,20 +31,21 @@ type TextareaProps = PropsOf<'textarea'> & {
 };
 
 export const Textarea = component$<TextareaProps>(
-  ({ id, name, error, ['bind:value']: valueSig, value, onInput$, ...props }) => {
+  ({ id, name, error, ['bind:value']: bindSig, value, onInput$, ...props }) => {
     const textareaId = id || name;
     return (
       <>
         <textarea
           {...props}
           // workaround to support two way data-binding on the Input component (https://github.com/QwikDev/qwik/issues/3926)
-          value={valueSig ? valueSig.value : value}
-          onInput$={valueSig ? $((__, el) => (valueSig.value = el.value)) : onInput$}
+          value={bindSig ? bindSig.value : value}
+          onInput$={[bindSig && $((_, el) => (bindSig.value = el.value)), onInput$]}
           class={cn(
             '[&::-webkit-scrollbar-track]:bg-blue flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
             props.class,
           )}
           id={textareaId}
+          name={name}
         />
         {error && <div id={`${textareaId}-error`}>{error}</div>}
       </>

--- a/packages/kit-styled/src/components/checkbox/checkbox.tsx
+++ b/packages/kit-styled/src/components/checkbox/checkbox.tsx
@@ -2,16 +2,16 @@ import { $, type PropsOf, component$ } from '@builder.io/qwik';
 import { cn } from '@qwik-ui/utils';
 
 export const Checkbox = component$<Partial<PropsOf<'input'> & { type?: 'checkbox' }>>(
-  ({ id, name, ['bind:checked']: checkedSig, checked, onInput$, ...props }) => {
+  ({ id, name, ['bind:checked']: bindSig, checked, onInput$, ...props }) => {
     const inputId = id || name;
     return (
       <input
         {...props}
         type="checkbox"
         // workaround to support two way data-binding on the Input component (https://github.com/QwikDev/qwik/issues/3926)
-        checked={checkedSig ? checkedSig.value : checked}
-        onInput$={checkedSig ? $((_, el) => (checkedSig.value = el.checked)) : onInput$}
-        data-checked={checked || checkedSig?.value || ''}
+        checked={bindSig ? bindSig.value : checked}
+        onInput$={[bindSig && $((_, el) => (bindSig.value = el.checked)), onInput$]}
+        data-checked={checked || bindSig?.value || ''}
         class={cn(
           'peer h-4 w-4 shrink-0 border-primary text-primary accent-primary ring-offset-background focus:ring-ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
           props.class,

--- a/packages/kit-styled/src/components/input/input.tsx
+++ b/packages/kit-styled/src/components/input/input.tsx
@@ -6,7 +6,7 @@ type InputProps = PropsOf<'input'> & {
 };
 
 export const Input = component$<InputProps>(
-  ({ name, error, id, ['bind:value']: valueSig, value, onInput$, ...props }) => {
+  ({ name, error, id, ['bind:value']: bindSig, value, onInput$, ...props }) => {
     const inputId = id || name;
 
     return (
@@ -16,8 +16,8 @@ export const Input = component$<InputProps>(
           aria-errormessage={`${inputId}-error`}
           aria-invalid={!!error}
           // workaround to support two way data-binding on the Input component (https://github.com/QwikDev/qwik/issues/3926)
-          value={valueSig ? valueSig.value : value}
-          onInput$={valueSig ? $((__, el) => (valueSig.value = el.value)) : onInput$}
+          value={bindSig ? bindSig.value : value}
+          onInput$={[bindSig && $((_, el) => (bindSig.value = el.value)), onInput$]}
           class={cn(
             'flex h-12 w-full rounded-base border border-input bg-background px-3 py-1 text-sm text-foreground shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
             props.class,

--- a/packages/kit-styled/src/components/textarea/textarea.tsx
+++ b/packages/kit-styled/src/components/textarea/textarea.tsx
@@ -6,20 +6,21 @@ type TextareaProps = PropsOf<'textarea'> & {
 };
 
 export const Textarea = component$<TextareaProps>(
-  ({ id, name, error, ['bind:value']: valueSig, value, onInput$, ...props }) => {
+  ({ id, name, error, ['bind:value']: bindSig, value, onInput$, ...props }) => {
     const textareaId = id || name;
     return (
       <>
         <textarea
           {...props}
           // workaround to support two way data-binding on the Input component (https://github.com/QwikDev/qwik/issues/3926)
-          value={valueSig ? valueSig.value : value}
-          onInput$={valueSig ? $((__, el) => (valueSig.value = el.value)) : onInput$}
+          value={bindSig ? bindSig.value : value}
+          onInput$={[bindSig && $((_, el) => (bindSig.value = el.value)), onInput$]}
           class={cn(
             '[&::-webkit-scrollbar-track]:bg-blue flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
             props.class,
           )}
           id={textareaId}
+          name={name}
         />
         {error && <div id={`${textareaId}-error`}>{error}</div>}
       </>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
