### PR TITLE
fix: modal closing with a custom animation, even if there are animated elements inside the modal

### DIFF
--- a/.changeset/itchy-bobcats-nail.md
+++ b/.changeset/itchy-bobcats-nail.md
@@ -1,0 +1,5 @@
+---
+'@qwik-ui/headless': patch
+---
+
+fix: modal closing with a custom animation now always works, even if there are animated elements inside the modal

--- a/packages/kit-headless/src/components/modal/use-modal.tsx
+++ b/packages/kit-headless/src/components/modal/use-modal.tsx
@@ -19,31 +19,29 @@ export function useModal() {
     const { animationDuration, transitionDuration } = getComputedStyle(modal);
 
     if (animationDuration !== '0s') {
-      modal.addEventListener(
-        'animationend',
-        (e) => {
-          if (e.target === modal) {
-            delete modal.dataset.closing;
-            modal.classList.remove('modal-closing');
-            enableBodyScroll(modal);
-            modal.close();
-          }
-        },
-        { once: true },
-      );
+      const handler = (e: AnimationEvent) => {
+        if (e.target === modal) {
+          delete modal.dataset.closing;
+          modal.classList.remove('modal-closing');
+          enableBodyScroll(modal);
+          modal.close();
+          modal.removeEventListener('animationend', handler);
+        }
+      };
+
+      modal.addEventListener('animationend', handler);
     } else if (transitionDuration !== '0s') {
-      modal.addEventListener(
-        'transitionend',
-        (e) => {
-          if (e.target === modal) {
-            delete modal.dataset.closing;
-            modal.classList.remove('modal-closing');
-            enableBodyScroll(modal);
-            modal.close();
-          }
-        },
-        { once: true },
-      );
+      const handler = (e: TransitionEvent) => {
+        if (e.target === modal) {
+          delete modal.dataset.closing;
+          modal.classList.remove('modal-closing');
+          enableBodyScroll(modal);
+          modal.close();
+          modal.removeEventListener('transitionend', handler);
+        }
+      };
+
+      modal.addEventListener('transitionend', handler);
     } else if (animationDuration === '0s' && transitionDuration === '0s') {
       delete modal.dataset.closing;
       modal.classList.remove('modal-closing');


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

<!-- Please link to an issue or describe why did you create this PR -->
`transitionend` and `animationend` events could fire on inner animations inside the modal instead of the modal container itself.
Because these listeners were registered with `{ once: true }`, they were removed after the first event, causing the modal closing logic to never run and leaving the modal partially open. As a result, the user could no longer interact with the page.

For example, if there is an animated `placeholder` on an `<input>` inside the modal, the `transitionend` event could fire on that placeholder before the modal’s own transition finishes. This would remove the listener too early and prevent the modal from closing completely.

Before:

https://github.com/user-attachments/assets/214a24fc-744b-405a-bde7-25703f708805

After:

https://github.com/user-attachments/assets/262b7712-eef8-4a84-b101-e0f28f22a596

Same issue
https://github.com/qwikifiers/qwik-ui/issues/1004

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [x] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
