### PR TITLE
fix: use type="button" for trigger components

### DIFF
--- a/packages/kit-headless/src/components/collapsible/collapsible-trigger.tsx
+++ b/packages/kit-headless/src/components/collapsible/collapsible-trigger.tsx
@@ -16,6 +16,7 @@ export const HCollapsibleTrigger = component$<PropsOf<'button'>>(
 
     return (
       <button
+        type="button"
         {...props}
         id={triggerId}
         ref={context.triggerRef}

--- a/packages/kit-headless/src/components/dropdown/dropdown-trigger.tsx
+++ b/packages/kit-headless/src/components/dropdown/dropdown-trigger.tsx
@@ -75,6 +75,7 @@ export const HDropdownTrigger = component$<DropdownTriggerProps>((props) => {
 
   return (
     <button
+      type="button"
       data-trigger
       {...props}
       id={triggerId}

--- a/packages/kit-headless/src/components/modal/modal-trigger.tsx
+++ b/packages/kit-headless/src/components/modal/modal-trigger.tsx
@@ -10,6 +10,7 @@ export const HModalTrigger = component$((props: PropsOf<'button'>) => {
 
   return (
     <button
+      type="button"
       aria-haspopup="dialog"
       aria-expanded={context.showSig.value}
       data-open={context.showSig.value ? '' : undefined}

--- a/packages/kit-headless/src/components/popover/popover-trigger.tsx
+++ b/packages/kit-headless/src/components/popover/popover-trigger.tsx
@@ -60,6 +60,7 @@ export const HPopoverTrigger = component$<PopoverTriggerProps>(
 
     return (
       <button
+        type="button"
         {...props}
         ref={context.triggerRef}
         id={triggerId}

--- a/packages/kit-headless/src/components/select/select-trigger.tsx
+++ b/packages/kit-headless/src/components/select/select-trigger.tsx
@@ -130,6 +130,7 @@ export const HSelectTrigger = component$<SelectTriggerProps>((props) => {
 
   return (
     <button
+      type="button"
       {...props}
       id={triggerId}
       ref={triggerRef}

--- a/packages/kit-headless/src/components/tooltip/tooltip-trigger.tsx
+++ b/packages/kit-headless/src/components/tooltip/tooltip-trigger.tsx
@@ -91,6 +91,7 @@ export const HTooltipTrigger = component$((props: PropsOf<'button'>) => {
 
   return (
     <button
+      type="button"
       ref={context.triggerRef}
       onMouseOver$={[preventDefaultSync$, setTooltipOpen$]}
       onMouseLeave$={setTooltipClosed$}


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?

\<button\> elements default to type="submit", which submit when clicked if used inside a form.
This leads to an annoying issue where using components like Modal inside of forms will submit the form when you attempt to interact with them.

This small patch fixes that by specifying type="button" in all of the .Trigger components.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
