### PR TITLE
fix: fix modal backdrop close click handling

### DIFF
--- a/.changeset/weak-walls-turn.md
+++ b/.changeset/weak-walls-turn.md
@@ -1,0 +1,5 @@
+---
+'@qwik-ui/headless': patch
+---
+
+fix: fix modal backdrop close click handling

--- a/packages/kit-headless/src/components/modal/modal-panel.tsx
+++ b/packages/kit-headless/src/components/modal/modal-panel.tsx
@@ -125,7 +125,7 @@ export const HModalPanel = component$((props: PropsOf<'dialog'>) => {
       role={context.alert === true ? 'alertdialog' : 'dialog'}
       ref={panelRef}
       onKeyDown$={[handleKeyDownSync$, handleKeyDown$, props.onKeyDown$]}
-      onClick$={async (e) => {
+      onMouseDown$={async (e) => {
         e.stopPropagation();
         await closeOnBackdropClick$(e);
       }}


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Why is it needed?
The modal backdrop click detection relied on the `click` event, which uses the pointer position at the moment of `mouseup`. This caused unintended behavior when the user started interaction inside the modal but released the mouse outside of it.

In such cases, the interaction was incorrectly interpreted as a backdrop click, triggering the modal to close even though the user did not intend to dismiss it.

For example, when selecting text inside the modal, the user may press the mouse button within the modal content and then move the cursor outside its bounds before releasing. The resulting `click` event would be registered outside the modal, causing it to close unexpectedly and interrupting the user interaction.

Switching to `onMouseDown$`ensures that the initial interaction point is used, preventing accidental modal closure during text selection or similar drag interactions.
<!-- Please link to an issue or describe why did you create this PR -->
Before


https://github.com/user-attachments/assets/f74a26b9-6fac-423f-a392-1b209e4192b1


After


https://github.com/user-attachments/assets/52bc33d6-8d7c-48e5-a571-d38711f12368


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [x] I have add necessary docs (if needed)
- [ ] Added new tests to cover the fix / functionality
