### PR TITLE
chore: add qwik-ui cli license metadata

### DIFF
--- a/.changeset/quiet-buckets-smile.md
+++ b/.changeset/quiet-buckets-smile.md
@@ -1,0 +1,5 @@
+---
+"qwik-ui": patch
+---
+
+Add MIT license metadata to the CLI package manifest.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,7 @@
     "directory": "packages/cli"
   },
   "description": "Qwik UI Command line interface",
+  "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.7.0",
     "@nx/devkit": "21.1.2",


### PR DESCRIPTION
## Summary
- Add MIT license metadata to the `qwik-ui` CLI package manifest.
- Include a patch changeset for the package metadata update.

## Validation
- `node -e "const p=require('./packages/cli/package.json'); if(p.license!=='MIT') process.exit(1); console.log(JSON.stringify({name:p.name,license:p.license}, null, 2))"`
- `git diff --check`