### PR TITLE
fix(qwik-ui-cli): add license MIT to package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,5 +28,6 @@
   "bin": {
     "qwik-ui": "./bin/index.js"
   },
-  "generators": "./generators.json"
+  "generators": "./generators.json",
+  "license": "MIT"
 }


### PR DESCRIPTION
The published `qwik-ui` CLI package is missing `license` metadata in `packages/cli/package.json`.

**Changes:**
- Add `"license": "MIT"` to `packages/cli/package.json`

Related: https://github.com/charles-openclaw/charles-microbounties/issues/849